### PR TITLE
Updated files for release 0.9.24

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+k2hdkc (0.9.24) unstable; urgency=low
+
+  * Fixed spec file and updated dependency
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Wed, 17 Oct 2018 20:28:44 +0900
+
+k2hdkc (0.9.23) unstable; urgency=low
+
+  * Wrong arguments in k2hdkc_pm_remove_str_subkey functions
+
+ -- Hirotaka Wakabayashi <hiwakaba@yahoo-corp.jp>  Mon, 13 Aug 2018 18:46:11 +0900
+
 k2hdkc (0.9.22) unstable; urgency=low
 
   * avoid static object initialization order problem(SIOF)

--- a/buildutils/control.in
+++ b/buildutils/control.in
@@ -2,7 +2,7 @@ Source: @PACKAGE_NAME@
 Section: database
 Priority: extra
 Maintainer: @DEV_NAME@ <@DEV_EMAIL@>
-Build-Depends: debhelper (>= 9), autotools-dev, k2hash-dev (>= 1.0.61), chmpx-dev (>= 1.0.62), libfullock-dev (>= 1.0.28), libyaml-dev
+Build-Depends: debhelper (>= 9), autotools-dev, k2hash-dev (>= 1.0.63), chmpx-dev (>= 1.0.63), libfullock-dev (>= 1.0.30), libyaml-dev
 Standards-Version: 3.9.5
 Homepage: https://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@
 Vcs-Git: git://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@.git
@@ -11,7 +11,7 @@ Vcs-Browser: https://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@
 Package: @PACKAGE_NAME@-dev
 Section: devel
 Architecture: amd64
-Depends: @PACKAGE_NAME@ (= ${binary:Version}), k2hash-dev (>= 1.0.61), chmpx-dev (>= 1.0.62), libfullock-dev (>= 1.0.28), libyaml-dev
+Depends: @PACKAGE_NAME@ (= ${binary:Version}), k2hash-dev (>= 1.0.63), chmpx-dev (>= 1.0.63), libfullock-dev (>= 1.0.30), libyaml-dev
 Description: @SHORTDESC@ (development)
  Development package for building with @PACKAGE_NAME@ shared library.
   This package has header files and symbols for it.
@@ -19,6 +19,6 @@ Description: @SHORTDESC@ (development)
 Package: @PACKAGE_NAME@
 Section: database
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, k2hash (>= 1.0.61), chmpx (>= 1.0.62), libfullock (>= 1.0.28)
+Depends: ${shlibs:Depends}, ${misc:Depends}, k2hash (>= 1.0.63), chmpx (>= 1.0.63), libfullock (>= 1.0.30)
 Description: @SHORTDESC@
 @DEBLONGDESC@

--- a/buildutils/k2hdkc.spec.in
+++ b/buildutils/k2hdkc.spec.in
@@ -47,8 +47,9 @@ License: @PKGLICENSE@
 Group: Applications/Databases
 URL: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@
 Source0: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@/archive/%{gittag}/%{name}-%{version}.tar.gz
+Requires: libfullock%{?_isa} >= 1.0.30, k2hash%{?_isa} >= 1.0.63, chmpx%{?_isa} >= 1.0.63
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
-BuildRequires: git-core gcc-c++ make libtool libfullock-devel%{?_isa} >= 1.0.28, k2hash-devel%{?_isa} >= 1.0.61, chmpx-devel%{?_isa} >= 1.0.62, libyaml-devel
+BuildRequires: git-core gcc-c++ make libtool libfullock-devel%{?_isa} >= 1.0.30, k2hash-devel%{?_isa} >= 1.0.63, chmpx-devel%{?_isa} >= 1.0.63, libyaml-devel
 Prefix: %{_prefix}
 
 %description
@@ -97,7 +98,7 @@ rm -rf %{buildroot}
 #
 %package devel
 Summary: @SHORTDESC@ (development)
-Requires: %{name}%{?_isa} = %{version}-%{release}, libfullock-devel%{?_isa} >= 1.0.28, k2hash-devel%{?_isa} >= 1.0.61, chmpx-devel%{?_isa} >= 1.0.62, libyaml-devel
+Requires: %{name}%{?_isa} = %{version}-%{release}, libfullock-devel%{?_isa} >= 1.0.30, k2hash-devel%{?_isa} >= 1.0.63, chmpx-devel%{?_isa} >= 1.0.63, libyaml-devel
 
 %description devel
 Development package for building with @PACKAGE_NAME@ shared library.

--- a/configure.ac
+++ b/configure.ac
@@ -124,9 +124,9 @@ AC_ARG_ENABLE(check-depend-libs,
 	esac]
 )
 AS_IF([test ${check_depend_libs} = 1], [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no)])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.28], [], [AC_MSG_ERROR(not found libfullock package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.61], [], [AC_MSG_ERROR(not found k2hash package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.62], [], [AC_MSG_ERROR(not found chmpx package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.30], [], [AC_MSG_ERROR(not found libfullock package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.63], [], [AC_MSG_ERROR(not found k2hash package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.63], [], [AC_MSG_ERROR(not found chmpx package)])])
 
 #
 # CFLAGS/CXXFLAGS

--- a/lib/k2hdkc.cc
+++ b/lib/k2hdkc.cc
@@ -2243,7 +2243,7 @@ bool k2hdkc_pm_remove_subkey(k2hdkc_chmpx_h handle, const unsigned char* pkey, s
 	return result;
 }
 
-bool k2hdkc_pm_remove_str_subkey(k2hdkc_chmpx_h handle, const char* pkey, const char* psubkey, size_t subkeylength, bool is_nest)
+bool k2hdkc_pm_remove_str_subkey(k2hdkc_chmpx_h handle, const char* pkey, const char* psubkey, bool is_nest)
 {
 	return k2hdkc_pm_remove_subkey(handle, reinterpret_cast<const unsigned char*>(pkey), (pkey ? strlen(pkey) + 1 : 0), reinterpret_cast<const unsigned char*>(psubkey), (psubkey ? strlen(psubkey) + 1 : 0), is_nest);
 }
@@ -2295,7 +2295,7 @@ bool k2hdkc_pm_remove_subkey_np(k2hdkc_chmpx_h handle, const unsigned char* pkey
 	return result;
 }
 
-bool k2hdkc_pm_remove_str_subkey_np(k2hdkc_chmpx_h handle, const char* pkey, const char* psubkey, size_t subkeylength, bool is_nest)
+bool k2hdkc_pm_remove_str_subkey_np(k2hdkc_chmpx_h handle, const char* pkey, const char* psubkey, bool is_nest)
 {
 	return k2hdkc_pm_remove_subkey_np(handle, reinterpret_cast<const unsigned char*>(pkey), (pkey ? strlen(pkey) + 1 : 0), reinterpret_cast<const unsigned char*>(psubkey), (psubkey ? strlen(psubkey) + 1 : 0), is_nest);
 }

--- a/lib/k2hdkc.h
+++ b/lib/k2hdkc.h
@@ -626,7 +626,7 @@ extern bool k2hdkc_ex_remove_subkey(const char* config, short ctlport, bool is_a
 extern bool k2hdkc_ex_remove_str_subkey(const char* config, short ctlport, bool is_auto_rejoin, bool no_giveup_rejoin, const char* pkey, const char* psubkey, bool is_nest);
 
 extern bool k2hdkc_pm_remove_subkey(k2hdkc_chmpx_h handle, const unsigned char* pkey, size_t keylength, const unsigned char* psubkey, size_t subkeylength, bool is_nest);
-extern bool k2hdkc_pm_remove_str_subkey(k2hdkc_chmpx_h handle, const char* pkey, const char* psubkey, size_t subkeylength, bool is_nest);
+extern bool k2hdkc_pm_remove_str_subkey(k2hdkc_chmpx_h handle, const char* pkey, const char* psubkey, bool is_nest);
 
 extern bool k2hdkc_remove_subkey_np(const char* config, const unsigned char* pkey, size_t keylength, const unsigned char* psubkey, size_t subkeylength, bool is_nest);
 extern bool k2hdkc_remove_str_subkey_np(const char* config, const char* pkey, const char* psubkey, bool is_nest);
@@ -635,7 +635,7 @@ extern bool k2hdkc_ex_remove_subkey_np(const char* config, short ctlport, bool i
 extern bool k2hdkc_ex_remove_str_subkey_np(const char* config, short ctlport, bool is_auto_rejoin, bool no_giveup_rejoin, const char* pkey, const char* psubkey, bool is_nest);
 
 extern bool k2hdkc_pm_remove_subkey_np(k2hdkc_chmpx_h handle, const unsigned char* pkey, size_t keylength, const unsigned char* psubkey, size_t subkeylength, bool is_nest);
-extern bool k2hdkc_pm_remove_str_subkey_np(k2hdkc_chmpx_h handle, const char* pkey, const char* psubkey, size_t subkeylength, bool is_nest);
+extern bool k2hdkc_pm_remove_str_subkey_np(k2hdkc_chmpx_h handle, const char* pkey, const char* psubkey, bool is_nest);
 
 //---------------------------------------------------------
 // Functions - Rename key


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 0.9.22 to 0.9.24

#### 0.9.23
- Wrong arguments in k2hdkc_pm_remove_str_subkey functions
  k2hdkc_pm_remove_str_subkey function had unnecessary arguments and deleted it.

#### 0.9.24
- Fixed spec file and updated dependency
  Added requires keyword in spec file for dependent packages and updated version for dependent packages.


