### PR TITLE
Added check using cppcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,6 +19,19 @@ SUBDIRS=docs lib src tests buildutils
 
 EXTRA_DIST=RELEASE_VERSION
 
+CPPCHECK_CMD=	cppcheck
+CPPCHECK_OPT=	--quiet \
+				--error-exitcode=1 \
+				--inline-suppr \
+				-j 4 \
+				--std=c++03 \
+				--xml \
+				--enable=warning,style,information,missingInclude
+CPPCHECK_IGN=
+
+cppcheck:
+	$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_IGN) $(SUBDIRS)
+
 #
 # VIM modelines
 #

--- a/buildutils/travis_builder.sh
+++ b/buildutils/travis_builder.sh
@@ -321,10 +321,27 @@ else
 	#
 	# Using RHSCL because centos has older ruby
 	#
-	run_cmd yum install -y -qq centos-release-scl
-	run_cmd yum install -y -qq rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake
+	run_cmd ${INSTALLER_BIN} install -y -qq centos-release-scl
+	run_cmd ${INSTALLER_BIN} install -y -qq rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake
 	source /opt/rh/rh-ruby23/enable
 	run_cmd ${GEM_BIN} install rubocop package_cloud
+fi
+
+#
+# For cppcheck
+#
+if [ ${IS_CENTOS} -eq 1 ]; then
+	#
+	# For CentOS, it need to allow EPEL(with setting disable)
+	#
+	run_cmd ${INSTALLER_BIN} install -y -qq epel-release
+	run_cmd yum-config-manager --disable epel
+	run_cmd ${INSTALLER_BIN} --enablerepo=epel install -y -qq cppcheck
+else
+	#
+	# Fedora, Ubuntu...
+	#
+	run_cmd ${INSTALLER_BIN} install -y -qq cppcheck
 fi
 
 #
@@ -337,6 +354,7 @@ SRCTOP="/tmp/${TMPSRCTOP}"
 run_cmd cd ${SRCTOP}
 run_cmd ./autogen.sh
 run_cmd ./configure --prefix=/usr ${CONFIGUREOPT}
+run_cmd make cppcheck
 run_cmd make
 run_cmd make check
 

--- a/lib/k2hdkc.cc
+++ b/lib/k2hdkc.cc
@@ -202,6 +202,8 @@ static bool DestoryOpenedMsgidSlaveObject(K2hdkcSlave* pSlave, bool is_clean_bup
 	if(!pSlave->Clean(is_clean_bup)){
 		WAN_DKCPRN("Failed to uninitialize slave chmpx, but continue...");
 	}
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress uselessAssignmentPtrArg
 	DKC_DELETE(pSlave);
 	return true;
 }
@@ -895,6 +897,7 @@ bool K2hdkcCvtSubkeysToPack(K2HSubKeys* pSubKeys, PK2HDKCKEYPCK* ppskeypck, int*
 	}
 	// copy
 	int	setpos = 0;
+	// cppcheck-suppress postfixOperator
 	for(K2HSubKeys::iterator iter = pSubKeys->begin(); iter != pSubKeys->end(); iter++){
 		if(0UL == iter->length){
 			WAN_DKCPRN("Subkey is empty.");
@@ -939,6 +942,7 @@ static int K2hdkcCvtSubkeysToStringArray(K2HSubKeys* pSubKeys, char*** ppskeyarr
 
 	// copy
 	int	setpos = 0;
+	// cppcheck-suppress postfixOperator
 	for(K2HSubKeys::iterator iter = pSubKeys->begin(); iter != pSubKeys->end(); iter++){
 		if(0UL == iter->length){
 			WAN_DKCPRN("Subkey is empty.");
@@ -1296,6 +1300,7 @@ bool K2hdkcCvtAttrsToPack(K2HAttrs* pAttrs, PK2HDKCATTRPCK* ppattrspck, int* pat
 	}
 	// copy
 	int	setpos = 0;
+	// cppcheck-suppress postfixOperator
 	for(K2HAttrs::iterator iter = pAttrs->begin(); iter != pAttrs->end(); iter++){
 		if(0UL == iter->keylength){
 			WAN_DKCPRN("Attr key is empty.");

--- a/lib/k2hdkccombase.cc
+++ b/lib/k2hdkccombase.cc
@@ -383,150 +383,200 @@ K2hdkcCommand* K2hdkcCommand::GetCommandSendObject(K2HShm* pk2hash, ChmCntrl* pc
 	if(DKC_COM_GET == comtype){
 		if(NULL == (pObj = new K2hdkcComGet(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_GET.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_GET_DIRECT == comtype){
 		if(NULL == (pObj = new K2hdkcComGetDirect(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_GET_DIRECT.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_GET_SUBKEYS == comtype){
 		if(NULL == (pObj = new K2hdkcComGetSubkeys(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_GET_SUBKEYS.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_GET_ATTRS == comtype){
 		if(NULL == (pObj = new K2hdkcComGetAttrs(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_GET_ATTRS.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_GET_ATTR == comtype){
 		if(NULL == (pObj = new K2hdkcComGetAttr(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_GET_ATTR.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_SET == comtype){
 		if(NULL == (pObj = new K2hdkcComSet(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_SET.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_SET_DIRECT == comtype){
 		if(NULL == (pObj = new K2hdkcComSetDirect(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_SET_DIRECT.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_SET_SUBKEYS == comtype){
 		if(NULL == (pObj = new K2hdkcComSetSubkeys(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_SET_SUBKEYS.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_SET_ALL == comtype){
 		if(NULL == (pObj = new K2hdkcComSetAll(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_SET_ALL.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_ADD_SUBKEYS == comtype){
 		if(NULL == (pObj = new K2hdkcComAddSubkeys(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_ADD_SUBKEYS.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_ADD_SUBKEY == comtype){
 		if(NULL == (pObj = new K2hdkcComAddSubkey(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_ADD_SUBKEY.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_DEL == comtype){
 		if(NULL == (pObj = new K2hdkcComDel(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_DEL.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_DEL_SUBKEYS == comtype){
 		if(NULL == (pObj = new K2hdkcComDelSubkeys(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_DEL_SUBKEYS.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_DEL_SUBKEY == comtype){
 		if(NULL == (pObj = new K2hdkcComDelSubkey(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_DEL_SUBKEY.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_REN == comtype){
 		if(NULL == (pObj = new K2hdkcComRen(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_REN.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_QPUSH == comtype){
 		if(NULL == (pObj = new K2hdkcComQPush(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_QPUSH.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_QPOP == comtype){
 		if(NULL == (pObj = new K2hdkcComQPop(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_QPOP.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_QDEL == comtype){
 		if(NULL == (pObj = new K2hdkcComQDel(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_QDEL.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_CAS_INIT == comtype){
 		if(NULL == (pObj = new K2hdkcComCasInit(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_CAS_INIT.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_CAS_GET == comtype){
 		if(NULL == (pObj = new K2hdkcComCasGet(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_CAS_GET.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_CAS_SET == comtype){
 		if(NULL == (pObj = new K2hdkcComCasSet(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_CAS_SET.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_CAS_INCDEC == comtype){
 		if(NULL == (pObj = new K2hdkcComCasIncDec(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_CAS_INCDEC.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_REPL_KEY == comtype){
 		if(NULL == (pObj = new K2hdkcComReplKey(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_REPL_KEY.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_K2HSTATE == comtype){
 		if(NULL == (pObj = new K2hdkcComK2hState(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_K2HSTATE.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
 	}else if(DKC_COM_STATE == comtype){
 		if(NULL == (pObj = new K2hdkcComState(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_STATE.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
 			return NULL;
 		}
 
@@ -601,7 +651,7 @@ K2hdkcCommand::~K2hdkcCommand(void)
 	// because this base class call it, and Clean() is virtual method.
 	// Thus you should implement only Clean() method in subclass.
 	//
-	Clean();
+	K2hdkcCommand::Clean();
 }
 
 //---------------------------------------------------------
@@ -768,6 +818,8 @@ bool K2hdkcCommand::SetReceiveData(PCOMPKT pComPkt, PDKCCOM_ALL pComAll)
 		return false;
 	}
 	// logging
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress literalWithCharPtrCompare
 	COMLOG_PRN(GetDispComNumber(), GetComNumber(), "Received %s: %s(%" PRIu64 ")", (DKC_NORESTYPE == pComAll->com_head.restype ? "command" : "response"), STR_DKCCOM_TYPE(pComAll->com_head.comtype), pComAll->com_head.comtype);
 
 	pRcvComPkt		= pComPkt;
@@ -855,9 +907,13 @@ bool K2hdkcCommand::ReplyResponse(void)
 
 	if(!pChmObj->Reply(pRcvComPkt, reinterpret_cast<unsigned char*>(pSendComAll), SendLength)){
 		ERR_DKCPRN("Failed to reply response.");
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress literalWithCharPtrCompare
 		COMLOG_DMP_PRN(GetDispComNumber(), GetComNumber(), "Failed to Reply command: %s(%" PRIu64 ")", STR_DKCCOM_TYPE(pSendComAll->com_head.comtype), pSendComAll->com_head.comtype);
 		return false;
 	}
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress literalWithCharPtrCompare
 	COMLOG_DMP_PRN(GetDispComNumber(), GetComNumber(), "Replied command: %s(%" PRIu64 ")", STR_DKCCOM_TYPE(pSendComAll->com_head.comtype), pSendComAll->com_head.comtype);
 
 	return true;
@@ -891,6 +947,8 @@ bool K2hdkcCommand::CommandSending(void)
 
 		// set callback
 		if(!K2hdkcCommand::WaitFp(pSendComAll->com_head.comnumber, this, K2hdkcCommand::pWaitFpParam)){
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress literalWithCharPtrCompare
 			ERR_DKCPRN("Failed to set receive waiting callback for type(%s).", STR_DKCCOM_TYPE(pSendComAll->com_head.comtype));
 			TriggerResponse = true;			// reset
 			return false;
@@ -915,9 +973,13 @@ bool K2hdkcCommand::CommandSending(void)
 			result = pChmObj->Send(SendMsgid, reinterpret_cast<unsigned char*>(pSendComAll), SendLength, SendHash, NULL, RoutingOnSlave);
 		}
 	}
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress literalWithCharPtrCompare
 	COMLOG_PRN(GetDispComNumber(), GetComNumber(), "Sent command: %s(%" PRIu64 ")", STR_DKCCOM_TYPE(pSendComAll->com_head.comtype), pSendComAll->com_head.comtype);
 
 	if(!result){
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress literalWithCharPtrCompare
 		ERR_DKCPRN("Failed to send command for type(%s).", STR_DKCCOM_TYPE(pSendComAll->com_head.comtype));
 
 		// Unset callback(a case of on server node)
@@ -925,6 +987,8 @@ bool K2hdkcCommand::CommandSending(void)
 			// unset callback
 			TriggerResponse = true;			// reset
 			if(!K2hdkcCommand::UnWaitFp(pSendComAll->com_head.comnumber, this, K2hdkcCommand::pWaitFpParam)){
+				// cppcheck-suppress unmatchedSuppression
+				// cppcheck-suppress literalWithCharPtrCompare
 				ERR_DKCPRN("Failed to unset receive waiting callback for type(%s).", STR_DKCCOM_TYPE(pSendComAll->com_head.comtype));
 			}
 		}
@@ -945,11 +1009,15 @@ bool K2hdkcCommand::CommandSending(void)
 		unsigned char*	pbody	= NULL;
 		size_t			length	= 0;
 		if(false == (result = pChmObj->Receive(SendMsgid, &pComPkt, &pbody, &length, K2hdkcCommand::RcvTimeout)) || !pComPkt || !pbody || 0 == length){
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress literalWithCharPtrCompare
 			ERR_DKCPRN("Failed to receive command response for type(%s) : pComPkt(%p), pbody(%p), length(%zu).", STR_DKCCOM_TYPE(pSendComAll->com_head.comtype), pComPkt, pbody, length);
 			DKC_FREE(pComPkt);
 			DKC_FREE(pbody);
 			return false;
 		}
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress literalWithCharPtrCompare
 		DMP_DKCPRN("Succeed to receive command response for type(%s) : pComPkt(%p), pbody(%p), length(%zu).", STR_DKCCOM_TYPE(pSendComAll->com_head.comtype), pComPkt, pbody, length);
 
 		DKC_FREE(pRcvComAll);
@@ -976,28 +1044,35 @@ bool K2hdkcCommand::CommandSending(void)
 
 			// wait condition
 			int	condres;
-			int	unlockres;
 			if(0 != (condres = pthread_mutex_lock(&cond_mutex))){
+				// cppcheck-suppress unmatchedSuppression
+				// cppcheck-suppress literalWithCharPtrCompare
 				ERR_DKCPRN("Could not lock mutex for condition by error code(%d), for command type(%s).", condres, STR_DKCCOM_TYPE(pSendComAll->com_head.comtype));
 				TriggerResponse = true;			// reset
 				result			= false;		// error
 
 			}else{
-				condres		= pthread_cond_timedwait(&cond_val, &cond_mutex, &abstimeout);
-				unlockres	= pthread_mutex_unlock(&cond_mutex);
+				condres			= pthread_cond_timedwait(&cond_val, &cond_mutex, &abstimeout);
+				int	unlockres	= pthread_mutex_unlock(&cond_mutex);
 				if(0 != unlockres){
+					// cppcheck-suppress unmatchedSuppression
+					// cppcheck-suppress literalWithCharPtrCompare
 					WAN_DKCPRN("Could not unlock mutex for condition by error code(%d), for command type(%s), but continue...", unlockres, STR_DKCCOM_TYPE(pSendComAll->com_head.comtype));
 				}
 
 				// check condition result
 				if(ETIMEDOUT == condres){
 					// timeouted
+					// cppcheck-suppress unmatchedSuppression
+					// cppcheck-suppress literalWithCharPtrCompare
 					ERR_DKCPRN("Could not get response for command type(%s) by timeout.", STR_DKCCOM_TYPE(pSendComAll->com_head.comtype));
 					TriggerResponse	= true;		// reset
 					result			= false;	// error
 
 				}else if(EINTR == condres){
 					// signal break
+					// cppcheck-suppress unmatchedSuppression
+					// cppcheck-suppress literalWithCharPtrCompare
 					MSG_DKCPRN("Could not get response for command type(%s) by signal, so retry to wait.", STR_DKCCOM_TYPE(pSendComAll->com_head.comtype));
 
 				}else if(0 != condres){
@@ -1095,6 +1170,8 @@ void K2hdkcCommand::DumpComAll(const char* pprefix, const PDKCCOM_ALL pComAll) c
 
 	// print head
 	RAW_DKCPRN("  DKCCOM_HEAD = {");
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress literalWithCharPtrCompare
 	RAW_DKCPRN("    comtype       = %s(0x%016" PRIx64 ")",	STR_DKCCOM_TYPE(pComAll->com_head.comtype), pComAll->com_head.comtype);
 	RAW_DKCPRN("    restype       = RESULT:0x%08" PRIx32 ", SUBCODE:0x%08" PRIx32 " (0x%016" PRIx64 ")", static_cast<uint32_t>(GET_DKC_RES_RESULT(pComAll->com_head.restype)), static_cast<uint32_t>(GET_DKC_RES_SUBCODE(pComAll->com_head.restype)), pComAll->com_head.restype);
 	RAW_DKCPRN("    comnumber     = 0x%016" PRIx64 , 		pComAll->com_head.comnumber);

--- a/lib/k2hdkccomdel.cc
+++ b/lib/k2hdkccomdel.cc
@@ -175,6 +175,7 @@ bool K2hdkcComDel::CommandSend(const unsigned char* pkey, size_t keylength, bool
 
 		}else{
 			// remove subkeys
+			// cppcheck-suppress postfixOperator
 			for(K2HSubKeys::iterator iter = pSubKeys->begin(); iter != pSubKeys->end(); iter++){
 				if(0UL == iter->length){
 					WAN_DKCPRN("Subkey is empty in key(%s).", bin_to_string(pkey, keylength).c_str());

--- a/lib/k2hdkcdbg.cc
+++ b/lib/k2hdkcdbg.cc
@@ -176,6 +176,8 @@ bool K2hdkcDbgControl::SetDbgCtrlFile(const char* filepath)
 	FILE*	newfp;
 	if(NULL == (newfp = fopen(filepath, "a+"))){
 		ERR_DKCPRN("Could not open debug file(%s). errno = %d", filepath, errno);
+		// cppcheck-suppress unmatchedSuppression
+		// cppcheck-suppress resourceLeak
 		return false;
 	}
 	*pk2hdkc_dbg_fp	= newfp;

--- a/lib/k2hdkcthread.cc
+++ b/lib/k2hdkcthread.cc
@@ -89,9 +89,10 @@ void* K2hdkcThread::WorkerProc(void* pparam)
 
 	// loop
 	struct timespec	abstimeout;
-	int				condres;
-	int				unlockres;
 	for(pthparam->result_code = 0, pthparam->idle_count = 0; !pthparam->stop_req; ){
+		int			condres;
+		int			unlockres;
+
 		// set new abstimeout
 		make_current_timespec_with_mergin(pthparam->sleep_ns, abstimeout);
 
@@ -159,7 +160,7 @@ void* K2hdkcThread::WorkerProc(void* pparam)
 			if(fullock::flck_trylock_noshared_mutex(&(pthparam->parent_obj->list_lockval))){		// LOCK
 				if(pthparam->parent_obj->min_thread_cnt < pthparam->parent_obj->run_thread_map.size() && 1 < pthparam->parent_obj->run_thread_map.size()){
 					// remove this
-					MSG_DKCPRN("This thread is idle count(%zu), and thread count in parent is over minimum count. so this thread is going to exit now.", pthparam->idle_count);
+					MSG_DKCPRN("This thread is idle count(%ld), and thread count in parent is over minimum count. so this thread is going to exit now.", pthparam->idle_count);
 
 					pthparam->parent_obj->run_thread_map.erase(pthparam->threadid);
 					pthparam->result_code = 0;
@@ -196,7 +197,7 @@ void* K2hdkcThread::WorkerProc(void* pparam)
 // Constructor/Destructor
 //---------------------------------------------------------
 K2hdkcThread::K2hdkcThread(void* pobj) :
-	pthread_paramobj(pobj), is_init_cond_vals(false), list_lockval(FLCK_NOSHARED_MUTEX_VAL_UNLOCKED),
+	pthread_paramobj(pobj), is_init_cond_vals(false), exit_notice(false), list_lockval(FLCK_NOSHARED_MUTEX_VAL_UNLOCKED),
 	min_thread_cnt(K2hdkcThread::MIN_THREAD_COUNT), max_thread_cnt(K2hdkcThread::MAX_THREAD_COUNT), free_thread_count(0),
 	reduce_idlecnt(K2hdkcThread::DEFAULT_REDUCE_IDLE_COUNT), auto_run_wpfp(NULL)
 {

--- a/lib/k2hdkcthread.h
+++ b/lib/k2hdkcthread.h
@@ -88,7 +88,7 @@ class K2hdkcThread
 		size_t JoinThreads(bool& is_rest_thread);
 
 	public:
-		K2hdkcThread(void* pobj = NULL);
+		explicit K2hdkcThread(void* pobj = NULL);
 		virtual ~K2hdkcThread();
 
 		bool Initialize(size_t minthcnt = K2hdkcThread::MIN_THREAD_COUNT, size_t maxthcnt = K2hdkcThread::MAX_THREAD_COUNT, time_t reduce_timeout = K2hdkcThread::DEFAULT_REDUCE_TIMEOUT);

--- a/lib/k2hdkcutil.cc
+++ b/lib/k2hdkcutil.cc
@@ -65,7 +65,7 @@ string bin_to_string(const unsigned char* pdata, size_t length, size_t maxlength
 		}
 		pbuff[dlength]	= '\0';
 		strresult		= pbuff;
-		DKC_DELETE(pbuff);
+		delete[] pbuff;
 
 		if(maxlength < length){
 			strresult += "...";

--- a/src/k2hdkccntrl.cc
+++ b/src/k2hdkccntrl.cc
@@ -284,8 +284,7 @@ bool K2hdkcCntrl::WorkerProc(void* pobj, bool* piswork)
 		}
 
 		// processing
-		bool	result;
-		if(false == (result = pComObj->CommandProcess())){
+		if(false == pComObj->CommandProcess()){
 			// this is command result, thus debug message level should be msg.
 			MSG_DKCPRN("Failed processing for received data.");
 		}
@@ -639,6 +638,8 @@ K2hdkcCommand* K2hdkcCntrl::FindWaitCommandObject(uint64_t comnum, dkccom_type_t
 					pcommap->erase(itercom);
 				}
 				// check empty
+				// cppcheck-suppress unmatchedSuppression
+				// cppcheck-suppress stlSize
 				if(0 == pcommap->size()){
 					DKC_DELETE(pcommap)
 					waitmap.erase(iternum);

--- a/src/k2hdkcconfparser.cc
+++ b/src/k2hdkcconfparser.cc
@@ -573,6 +573,8 @@ bool K2hdkcConfig::LoadYaml(const char* config, bool is_json_string)
 		// open configuration file
 		if(NULL == (fp = fopen(config, "r"))){
 			ERR_DKCPRN("Could not open configuration file(%s). errno = %d", config, errno);
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress resourceLeak
 			return false;
 		}
 		// set file to parser

--- a/tests/k2hdkclinetool.cc
+++ b/tests/k2hdkclinetool.cc
@@ -148,9 +148,9 @@ class LapTime
 		struct timeval	start;
 
 	public:
-		static bool Toggle(void) { return LapTime::Set(!LapTime::isEnable); }
-		static bool Enable(void) { return LapTime::Set(true); }
-		static bool Disable(void) { return LapTime::Set(false); }
+		static bool Toggle(void) { return Set(!LapTime::isEnable); }
+		static bool Enable(void) { return Set(true); }
+		static bool Disable(void) { return Set(false); }
 		static bool IsEnable(void) { return isEnable; }
 
 		LapTime();
@@ -955,7 +955,6 @@ static bool LineOptionParser(const char* pCommand, option_t& opts)
 			if(isQuart){
 				// pattern: "...."
 				if('\"' == *pPos){
-					isQuart = false;
 					if(0 == isspace(*(pPos + sizeof(char))) && '\0' != *(pPos + sizeof(char))){
 						ERR("Quart is not matching.");
 						return false;
@@ -995,7 +994,6 @@ static bool LineOptionParser(const char* pCommand, option_t& opts)
 			if(0 == isspace(*pPos)){
 				strParameter.clear();
 				isMakeParamter	= true;
-				isQuart			= false;
 
 				if('\"' == *pPos){
 					isQuart		= true;
@@ -1045,11 +1043,11 @@ static bool LineOptionParser(const char* pCommand, option_t& opts)
 //
 static bool ReadLine(int fd, string& line)
 {
-	char	szBuff;
-	ssize_t	readlength;
-
 	line.erase();
 	while(true){
+		char	szBuff;
+		ssize_t	readlength;
+
 		szBuff = '\0';
 		// read one character
 		if(-1 == (readlength = read(fd, &szBuff, 1))){
@@ -2070,10 +2068,11 @@ static bool CopyFileCommand(k2hdkc_chmpx_h chmpxhandle, params_t& params)
 	}
 
 	// loop
-	size_t			reqsize;
-	off_t			reqoffset;
-	unsigned char*	pval;
 	for(size_t totalvallen = 0L, vallength = 0L; totalvallen < length; totalvallen += vallength){
+		size_t			reqsize;
+		off_t			reqoffset;
+		unsigned char*	pval;
+
 		// get value
 		reqsize		= min(static_cast<size_t>(MAX_ONE_VALUE_LENGTH), (length - totalvallen));
 		reqoffset	= offset + totalvallen;
@@ -2351,10 +2350,11 @@ static bool SetFileCommand(k2hdkc_chmpx_h chmpxhandle, params_t& params)
 	}
 
 	// loop
-	size_t			reqsize;
-	off_t			reqoffset;
-	unsigned char*	pval;
 	for(size_t totallen = 0L, vallen = 0L; totallen < flen; totallen += vallen){
+		unsigned char*	pval;
+		off_t			reqoffset;
+		size_t			reqsize;
+
 		// read
 		reqsize		= min(static_cast<size_t>(10), (flen - totallen));
 		reqoffset	= static_cast<off_t>(totallen);
@@ -3024,8 +3024,6 @@ static bool RemoveSubkeyCommand(k2hdkc_chmpx_h chmpxhandle, params_t& params)
 				}
 
 				// convert
-				unsigned char*	psubkeys	= NULL;
-				size_t			subkeyslen	= 0;
 				if(!K2hdkcCvtPackToSubkeys(pnewskeypck, newskeypckcnt, &psubkeys, &subkeyslen)){
 					ERR("Something error occurred adding new subkey into subkeys array.");
 					DKC_FREE_KEYPACK(pnewskeypck, newskeypckcnt);
@@ -3085,8 +3083,6 @@ static bool RemoveSubkeyCommand(k2hdkc_chmpx_h chmpxhandle, params_t& params)
 				}
 
 				// convert
-				unsigned char*	psubkeys	= NULL;
-				size_t			subkeyslen	= 0;
 				if(!K2hdkcCvtPackToSubkeys(pnewskeypck, newskeypckcnt, &psubkeys, &subkeyslen)){
 					ERR("Something error occurred adding new subkey into subkeys array.");
 					DKC_FREE_KEYPACK(pnewskeypck, newskeypckcnt);
@@ -5245,6 +5241,7 @@ static bool HistoryCommand(ConsoleInput& InputIF)
 	const strarr_t&	history = InputIF.GetAllHistory();
 
 	int	nCnt = 1;
+	// cppcheck-suppress postfixOperator
 	for(strarr_t::const_iterator iter = history.begin(); iter != history.end(); iter++, nCnt++){
 		PRN(" %d  %s", nCnt, iter->c_str());
 	}
@@ -5263,6 +5260,7 @@ static bool SaveCommand(ConsoleInput& InputIF, params_t& params)
 	}
 
 	const strarr_t&	history = InputIF.GetAllHistory();
+	// cppcheck-suppress postfixOperator
 	for(strarr_t::const_iterator iter = history.begin(); iter != history.end(); iter++){
 		// check except command for writing file
 		if(	0 == strncasecmp(iter->c_str(), "his",		strlen("his"))		||
@@ -5401,6 +5399,8 @@ static bool CommandStringHandle(k2hdkc_chmpx_h chmpxhandle, ConsoleInput& InputI
 	if(!LineOptionParser(pCommand, opts)){
 		return true;	// for continue.
 	}
+	// cppcheck-suppress unmatchedSuppression
+	// cppcheck-suppress stlSize
 	if(0 == opts.size()){
 		return true;
 	}

--- a/tests/k2hdkclinetool.log
+++ b/tests/k2hdkclinetool.log
@@ -595,6 +595,7 @@ SUCCEED
 > rmsub test-key test-subkey1
 > print test-key
 "test-key" => "test-value"
+    subkey: "test-subkey2"
 > print test-subkey1
 "test-subkey1" => "test-sub-value"
 > print test-subkey2
@@ -614,6 +615,7 @@ SUCCEED
 > rmsub test-key test-subkey1 rmsub
 > print test-key
 "test-key" => "test-value"
+    subkey: "test-subkey2"
 > print test-subkey1
 "test-subkey1" => value is not found
 > print test-subkey2
@@ -1449,6 +1451,7 @@ SUCCEED
 > rmsub test-key test-subkey1
 > print test-key
 "test-key" => "test-value"
+    subkey: "test-subkey2"
 > print test-subkey1
 "test-subkey1" => "test-sub-value"
 > print test-subkey2
@@ -1468,6 +1471,7 @@ SUCCEED
 > rmsub test-key test-subkey1 rmsub
 > print test-key
 "test-key" => "test-value"
+    subkey: "test-subkey2"
 > print test-subkey1
 "test-subkey1" => value is not found
 > print test-subkey2


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Added cppcheck
We made use of cppcheck.  
cppcheck will automatically run on TravisCI.  
If you want to run it manually, please use `make cppcheck`.  

In this PR, we corrected errors etc. detected by cppcheck.

#### NOTE
cppcheck depends on the OS of the build environment, and different versions are used for each.  
This PR is trying to eliminate this difference.
