### PR TITLE
Fixed a bug that replication of key deletion was not performed

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -50,6 +50,7 @@ pkginclude_HEADERS	=	k2hdkccommon.h \
 						k2hdkccomreplkey.h \
 						k2hdkccomk2hstate.h \
 						k2hdkccomstate.h \
+						k2hdkccomrepldel.h \
 						k2hdkcthread.h \
 						k2hdkcslave.h \
 						k2hdkccomutil.h
@@ -93,6 +94,7 @@ libk2hdkc_la_SOURCES=	k2hdkcdbg.cc \
 						k2hdkccomreplkey.cc \
 						k2hdkccomk2hstate.cc \
 						k2hdkccomstate.cc \
+						k2hdkccomrepldel.cc \
 						k2hdkcthread.cc \
 						k2hdkcslave.cc \
 						k2hdkcversion.cc

--- a/lib/k2hdkccombase.cc
+++ b/lib/k2hdkccombase.cc
@@ -50,6 +50,7 @@
 #include "k2hdkccomreplkey.h"
 #include "k2hdkccomk2hstate.h"
 #include "k2hdkccomstate.h"
+#include "k2hdkccomrepldel.h"
 #include "k2hdkccomutil.h"
 #include "k2hdkcutil.h"
 #include "k2hdkcdbg.h"
@@ -84,7 +85,8 @@ static const char*	str_dkccom_type[] = {
 	"DKC_COM_CAS_INCDEC",
 	"DKC_COM_REPL_KEY",
 	"DKC_COM_K2HSTATE",
-	"DKC_COM_STATE"
+	"DKC_COM_STATE",
+	"DKC_COM_REPL_DEL"
 };
 
 const char* STR_DKCCOM_TYPE(dkccom_type_t comtype)
@@ -332,6 +334,14 @@ K2hdkcCommand* K2hdkcCommand::GetCommandReceiveObject(K2HShm* pk2hash, ChmCntrl*
 		K2hdkcComReplKey*	pComObj = new K2hdkcComReplKey(pk2hash, pchmcntrl, pComAll->com_head.comnumber);
 		if(!pComObj){
 			ERR_DKCPRN("Could not make command object for DKC_COM_REPL_KEY.");
+			return NULL;
+		}
+		pObj = pComObj;
+
+	}else if(DKC_COM_REPL_DEL == pComAll->com_head.comtype){
+		K2hdkcComReplDel*	pComObj = new K2hdkcComReplDel(pk2hash, pchmcntrl, pComAll->com_head.comnumber);
+		if(!pComObj){
+			ERR_DKCPRN("Could not make command object for DKC_COM_REPL_DEL.");
 			return NULL;
 		}
 		pObj = pComObj;
@@ -601,6 +611,14 @@ K2hdkcCommand* K2hdkcCommand::GetCommandSendObject(K2HShm* pk2hash, ChmCntrl* pc
 	}else if(DKC_COM_REPL_KEY == comtype){
 		if(NULL == (pObj = new K2hdkcComReplKey(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
 			ERR_DKCPRN("Could not make command object for DKC_COM_REPL_KEY.");
+			// cppcheck-suppress unmatchedSuppression
+			// cppcheck-suppress memleak
+			return NULL;
+		}
+
+	}else if(DKC_COM_REPL_DEL == comtype){
+		if(NULL == (pObj = new K2hdkcComReplDel(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server))){
+			ERR_DKCPRN("Could not make command object for DKC_COM_REPL_DEL.");
 			// cppcheck-suppress unmatchedSuppression
 			// cppcheck-suppress memleak
 			return NULL;

--- a/lib/k2hdkccomrepldel.cc
+++ b/lib/k2hdkccomrepldel.cc
@@ -1,0 +1,268 @@
+/*
+ * 
+ * K2HDKC
+ * 
+ * Copyright 2016 Yahoo Japan Corporation.
+ * 
+ * K2HDKC is k2hash based distributed KVS cluster.
+ * K2HDKC uses K2HASH, CHMPX, FULLOCK libraries. K2HDKC supports
+ * distributed KVS cluster server program and client libraries.
+ * 
+ * For the full copyright and license information, please view
+ * the license file that was distributed with this source code.
+ *
+ * AUTHOR:   Takeshi Nakatani
+ * CREATE:   Mon May 23 2020
+ * REVISION:
+ * 
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include "k2hdkccomrepldel.h"
+#include "k2hdkcutil.h"
+#include "k2hdkcdbg.h"
+
+using namespace	std;
+
+//---------------------------------------------------------
+// Constructor/Destructor
+//---------------------------------------------------------
+K2hdkcComReplDel::K2hdkcComReplDel(K2HShm* pk2hash, ChmCntrl* pchmcntrl, uint64_t comnum, bool without_self, bool is_routing_on_server, bool is_wait_on_server) : K2hdkcCommand(pk2hash, pchmcntrl, comnum, without_self, is_routing_on_server, is_wait_on_server, DKC_COM_REPL_DEL)
+{
+	strClassName = "K2hdkcComReplDel";
+
+	// [NOTE]
+	// This command must be replicate mode for all case.
+	// (RoutingOnSlave does not care, but set here.)
+	//
+	SetReplicateSend();
+	UnsetRoutingOnSlave();
+}
+
+K2hdkcComReplDel::~K2hdkcComReplDel(void)
+{
+}
+
+//---------------------------------------------------------
+// Methods
+//---------------------------------------------------------
+PDKCCOM_ALL K2hdkcComReplDel::MakeResponseOnlyHeadData(dkcres_type_t subcode, dkcres_type_t errcode)
+{
+	PDKCCOM_ALL	pComErr;
+	if(NULL == (pComErr = reinterpret_cast<PDKCCOM_ALL>(malloc(sizeof(DKCRES_REPL_DEL))))){
+		ERR_DKCPRN("Could not allocate memory.");
+		return NULL;
+	}
+	PDKCRES_REPL_DEL	pComRes	= CVT_DKCRES_REPL_DEL(pComErr);
+	pComRes->head.comtype		= DKC_COM_REPL_DEL;
+	pComRes->head.restype		= COMPOSE_DKC_RES(errcode, subcode);
+	pComRes->head.comnumber		= GetComNumber();
+	pComRes->head.dispcomnumber	= GetDispComNumber();
+	pComRes->head.length		= sizeof(DKCRES_REPL_DEL);
+
+	return pComErr;
+}
+
+bool K2hdkcComReplDel::SetSucceedResponseData(void)
+{
+	PDKCCOM_ALL	pComAll = MakeResponseOnlyHeadData(DKC_RES_SUBCODE_NOTHING, DKC_RES_SUCCESS);
+
+	if(!SetResponseData(pComAll)){
+		ERR_DKCPRN("Failed to set send data.");
+		DKC_FREE(pComAll);
+		SetErrorResponseData(DKC_RES_SUBCODE_INTERNAL);
+		return false;
+	}
+	return true;
+}
+
+bool K2hdkcComReplDel::CommandProcessing(void)
+{
+	if(!pChmObj || !pRcvComPkt || !pRcvComAll || 0 == RcvComLength){
+		ERR_DKCPRN("This object does not initialize yet.");
+		SetErrorResponseData(DKC_RES_SUBCODE_INTERNAL);
+		return false;
+	}
+
+	if(DKC_NORESTYPE == pRcvComAll->com_head.restype){
+		//
+		// receive data is command
+		//
+		if(!pK2hObj || !IsServerNode){
+			ERR_DKCPRN("This object does not initialize yet.");
+			SetErrorResponseData(DKC_RES_SUBCODE_INTERNAL);
+			return false;
+		}
+
+		// get command data
+		const PDKCCOM_REPL_DEL	pCom = CVT_DKCCOM_REPL_DEL(pRcvComAll);
+		const unsigned char*	pKey = GET_BIN_DKC_COM_ALL(pRcvComAll, pCom->key_offset, pCom->key_length);
+		if(!pKey){
+			ERR_DKCPRN("Could not get safe key(%zd offset, %zu byte) in DKCCOM_REPL_DEL(%p).", pCom->key_offset, pCom->key_length, pRcvComAll);
+			SetErrorResponseData(DKC_RES_SUBCODE_INVAL);
+			return false;
+		}
+
+		// check mtime in attributes
+		K2HAttrs*	pAttrsObj = NULL;
+		if(NULL == (pAttrsObj = pK2hObj->GetAttrs(pKey, pCom->key_length))){
+			// there is no attributes for key or the key is not existed.
+			WAN_DKCPRN("There is no attributes for key(%s), so it allows to remove this key.", bin_to_string(pKey, pCom->key_length).c_str());
+		}else{
+			K2hAttrOpsMan	attrman;
+			if(!attrman.Initialize(pK2hObj, pKey, pCom->key_length, NULL, 0UL, NULL)){
+				// something wrong to get information, but continue...
+				WAN_DKCPRN("Something wrong to get attribute information from key(%s), so it allows to remove this key.", bin_to_string(pKey, pCom->key_length).c_str());
+			}else{
+				// get mtime( we do not check the key expired )
+				struct timespec	mtime;
+				if(!attrman.GetMTime(*pAttrsObj, mtime)){
+					// The existed key does not have mtime
+					WAN_DKCPRN("key(%s) does not have mtime attribute, so it allows to remove this key.", bin_to_string(pKey, pCom->key_length).c_str());
+				}else{
+					// compare timespec
+					if(pCom->ts.tv_sec < mtime.tv_sec || (pCom->ts.tv_sec == mtime.tv_sec && pCom->ts.tv_nsec < mtime.tv_nsec)){
+						WAN_DKCPRN("the existing key(%s) mtime is newer than requested time, so we do not remove it.", bin_to_string(pKey, pCom->key_length).c_str());
+						DKC_DELETE(pAttrsObj);
+						SetErrorResponseData(DKC_RES_SUBCODE_REPL);
+						return false;
+					}
+					//MSG_DKCPRN("the existing key(%s) mtime is older than requested time, so we continue to remove processing..", bin_to_string(pKey, pCom->key_length).c_str());
+				}
+			}
+			DKC_DELETE(pAttrsObj);
+		}
+
+		// do command
+		// 
+		if(!pK2hObj->Remove(pKey, pCom->key_length, false)){							// [NOTICE] do not remove subkeys
+			ERR_DKCPRN("Failed to remove key(%s)", bin_to_string(pKey, pCom->key_length).c_str());
+			SetErrorResponseData(DKC_RES_SUBCODE_REPL);
+			return false;
+		}
+
+		// set response data
+		SetSucceedResponseData();
+
+	}else{
+		//
+		// receive data is response
+		//
+		// get receive data
+		const PDKCRES_REPL_DEL	pComRes = CVT_DKCRES_REPL_DEL(pRcvComAll);
+
+		// print result
+		DKC_RES_PRINT(pComRes->head.comtype, pComRes->head.restype);
+	}
+	return true;
+}
+
+bool K2hdkcComReplDel::CommandSend(k2h_hash_t hash, k2h_hash_t subhash, const unsigned char* pkey, size_t keylength, const struct timespec ts)
+{
+	if(!pkey || 0 == keylength){
+		ERR_DKCPRN("Parameter are wrong.");
+		return false;
+	}
+	if(!IsServerNode){
+		MSG_DKCPRN("This DKC_COM_REPL_DEL command must be sent on server node.");
+		return false;
+	}
+
+	// make send data
+	PDKCCOM_ALL	pComAll;
+	if(NULL == (pComAll = reinterpret_cast<PDKCCOM_ALL>(malloc(sizeof(DKCCOM_REPL_DEL) + keylength)))){
+		ERR_DKCPRN("Could not allocate memory.");
+		return false;
+	}
+	PDKCCOM_REPL_DEL	pComReplDel	= CVT_DKCCOM_REPL_DEL(pComAll);
+	pComReplDel->head.comtype		= DKC_COM_REPL_DEL;
+	pComReplDel->head.restype		= DKC_NORESTYPE;
+	pComReplDel->head.comnumber		= GetComNumber();
+	pComReplDel->head.dispcomnumber	= GetDispComNumber();
+	pComReplDel->head.length		= sizeof(DKCCOM_REPL_DEL) + keylength;
+	pComReplDel->hash				= hash;
+	pComReplDel->subhash			= subhash;
+	pComReplDel->key_offset			= sizeof(DKCCOM_REPL_DEL);
+	pComReplDel->key_length			= keylength;
+	pComReplDel->ts					= ts;
+
+	unsigned char*	pdata			= reinterpret_cast<unsigned char*>(pComReplDel) + pComReplDel->key_offset;
+	memcpy(pdata, pkey, keylength);
+
+	if(!SetSendData(pComAll, K2hdkcCommand::MakeChmpxHash((reinterpret_cast<unsigned char*>(pComReplDel) + pComReplDel->key_offset), keylength))){
+		ERR_DKCPRN("Failed to set command data to internal buffer.");
+		DKC_FREE(pComAll);
+		return false;
+	}
+
+	// do command & receive response(on slave node)
+	if(!CommandSend()){
+		ERR_DKCPRN("Failed to send command.");
+		return false;
+	}
+	return true;
+}
+
+bool K2hdkcComReplDel::CommandSend(k2h_hash_t hash, k2h_hash_t subhash, const unsigned char* pkey, size_t keylength, const struct timespec ts, dkcres_type_t* prescode)
+{
+	if(!pChmObj){
+		ERR_DKCPRN("Chmpx object is NULL, so could not send command.");
+		return false;
+	}
+
+	if(!CommandSend(hash, subhash, pkey, keylength, ts)){
+		ERR_DKCPRN("Failed to send command.");
+		return false;
+	}
+	return GetResponseData(prescode);
+}
+
+bool K2hdkcComReplDel::GetResponseData(dkcres_type_t* prescode) const
+{
+	PDKCCOM_ALL	pcomall = NULL;
+	if(!K2hdkcCommand::GetResponseData(&pcomall, NULL, prescode) || !pcomall){
+		ERR_DKCPRN("Failed to get result.");
+		return false;
+	}
+	if(DKC_NORESTYPE == pcomall->com_head.restype){
+		ERR_DKCPRN("Response(received) data is not received data type.");
+		return false;
+	}
+	return true;
+}
+
+//---------------------------------------------------------
+// Methods - Dump
+//---------------------------------------------------------
+void K2hdkcComReplDel::RawDumpComAll(const PDKCCOM_ALL pComAll) const
+{
+	assert(DKC_COM_REPL_DEL == pComAll->com_head.comtype);
+
+	if(DKC_NORESTYPE == pComAll->com_head.restype){
+		PDKCCOM_REPL_DEL	pCom = CVT_DKCCOM_REPL_DEL(pComAll);
+
+		RAW_DKCPRN("  DKCCOM_REPL_DEL = {");
+		RAW_DKCPRN("    hash            = 0x%016" PRIx64 ,		pCom->hash);
+		RAW_DKCPRN("    subhash         = 0x%016" PRIx64 ,		pCom->subhash);
+		RAW_DKCPRN("    key_offset      = (%016" PRIx64 ") %s",	pCom->key_offset, bin_to_string(GET_BIN_DKC_COM_ALL(pComAll, pCom->key_offset, pCom->key_length), pCom->key_length).c_str());
+		RAW_DKCPRN("    key_length      = %zu",					pCom->key_length);
+		RAW_DKCPRN("    ts              = %s (%s)",				STR_DKC_TIMESPEC(&(pCom->ts)).c_str(), STR_DKC_TIMESPEC_NS(&(pCom->ts)).c_str());
+		RAW_DKCPRN("  }");
+
+	}else{
+		//PDKCRES_REPL_DEL	pCom = CVT_DKCRES_REPL_DEL(pComAll);
+		RAW_DKCPRN("  DKCRES_REPL_DEL = {");
+			// nothing to print member
+		RAW_DKCPRN("  }");
+	}
+}
+
+/*
+ * VIM modelines
+ *
+ * vim:set ts=4 fenc=utf-8:
+ */

--- a/lib/k2hdkccomrepldel.h
+++ b/lib/k2hdkccomrepldel.h
@@ -12,20 +12,20 @@
  * the license file that was distributed with this source code.
  *
  * AUTHOR:   Takeshi Nakatani
- * CREATE:   Thu Jul 28 2016
+ * CREATE:   Wed Jul 20 2016
  * REVISION:
  * 
  */
 
-#ifndef	K2HDKCCOMDEL_H
-#define	K2HDKCCOMDEL_H
+#ifndef	K2HDKCCOMREPLDEL_H
+#define	K2HDKCCOMREPLDEL_H
 
 #include "k2hdkccombase.h"
 
 //---------------------------------------------------------
-// K2hdkcComDel Class
+// K2hdkcComReplDel Class
 //---------------------------------------------------------
-class K2hdkcComDel : public K2hdkcCommand
+class K2hdkcComReplDel : public K2hdkcCommand
 {
 	using	K2hdkcCommand::SetResponseData;
 	using	K2hdkcCommand::CommandSend;
@@ -35,23 +35,20 @@ class K2hdkcComDel : public K2hdkcCommand
 		virtual PDKCCOM_ALL MakeResponseOnlyHeadData(dkcres_type_t subcode = DKC_RES_SUBCODE_NOTHING, dkcres_type_t errcode = DKC_RES_ERROR);
 		bool SetSucceedResponseData(void);
 
-		virtual bool CommandReplicate(const unsigned char* pkey, size_t keylength, const struct timespec ts);
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
-		bool IsAllNodesSafe(void);
-
 	public:
-		K2hdkcComDel(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
-		virtual ~K2hdkcComDel(void);
+		K2hdkcComReplDel(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		virtual ~K2hdkcComReplDel(void);
 
 		virtual bool CommandProcessing(void);
 
-		bool CommandSend(const unsigned char* pkey, size_t keylength, bool is_subkeys, bool checkattr = true);
-		bool CommandSend(const unsigned char* pkey, size_t keylength, bool is_subkeys, bool checkattr, dkcres_type_t* prescode);
+		bool CommandSend(k2h_hash_t hash, k2h_hash_t subhash, const unsigned char* pkey, size_t keylength, const struct timespec ts);
+		bool CommandSend(k2h_hash_t hash, k2h_hash_t subhash, const unsigned char* pkey, size_t keylength, const struct timespec ts, dkcres_type_t* prescode);
 		bool GetResponseData(dkcres_type_t* prescode) const;
 };
 
-#endif	// K2HDKCCOMDEL_H
+#endif	// K2HDKCCOMREPLDEL_H
 
 /*
  * VIM modelines

--- a/lib/k2hdkccomstructure.h
+++ b/lib/k2hdkccomstructure.h
@@ -66,7 +66,8 @@ DECL_EXTERN_C_START
 #define	DKC_COM_REPL_KEY				(DKC_COM_CAS_INCDEC		+ 1L)
 #define	DKC_COM_K2HSTATE				(DKC_COM_REPL_KEY		+ 1L)
 #define	DKC_COM_STATE					(DKC_COM_K2HSTATE		+ 1L)
-#define	DKC_COM_MAX						(DKC_COM_STATE)
+#define	DKC_COM_REPL_DEL				(DKC_COM_STATE			+ 1L)
+#define	DKC_COM_MAX						(DKC_COM_REPL_DEL)
 #if defined(__cplusplus)
 #define	DKC_COM_UNKNOWN					static_cast<dkccom_type_t>(-1)
 #else
@@ -546,6 +547,21 @@ typedef struct k2hdkc_com_k2hstate{
 	chmhash_t		base_hash;
 }K2HDKC_ATTR_PACKED DKCCOM_K2HSTATE, *PDKCCOM_K2HSTATE;
 
+//
+// Replicate deletion
+//
+// [NOTE]
+// This command is sent only clients on server node.
+//
+typedef struct k2hdkc_com_replicate_del{
+	DKCCOM_HEAD		head;
+	k2h_hash_t		hash;
+	k2h_hash_t		subhash;
+	off_t			key_offset;
+	size_t			key_length;
+	struct timespec	ts;
+}K2HDKC_ATTR_PACKED DKCCOM_REPL_DEL, *PDKCCOM_REPL_DEL;
+
 //---------------------------------------------------------
 // Command response structures
 //---------------------------------------------------------
@@ -734,7 +750,6 @@ typedef struct k2hdkc_res_cas_incdec{
 	DKCCOM_HEAD		head;
 }K2HDKC_ATTR_PACKED DKCRES_CAS_INCDEC, *PDKCRES_CAS_INCDEC;
 
-
 //
 // Response Replicate key
 //
@@ -749,6 +764,13 @@ typedef struct k2hdkc_res_k2hstate{
 	DKCCOM_HEAD		head;
 	DKC_NODESTATE	nodestate;
 }K2HDKC_ATTR_PACKED DKCRES_K2HSTATE, *PDKCRES_K2HSTATE;
+
+//
+// Response Replicate deletion
+//
+typedef struct k2hdkc_res_replicate_del{
+	DKCCOM_HEAD		head;
+}K2HDKC_ATTR_PACKED DKCRES_REPL_DEL, *PDKCRES_REPL_DEL;
 
 //
 // Response State
@@ -793,6 +815,7 @@ typedef union k2hdkc_com_all{
 	DKCCOM_CAS_INCDEC		com_cas_incdec;
 	DKCCOM_REPL_KEY			com_repl_key;
 	DKCCOM_K2HSTATE			com_k2hstate;
+	DKCCOM_REPL_DEL			com_repl_del;
 
 	DKCRES_GET				res_get;
 	DKCRES_GET_DIRECT		res_get_direct;
@@ -819,6 +842,7 @@ typedef union k2hdkc_com_all{
 	DKCRES_REPL_KEY			res_repl_key;
 	DKCRES_K2HSTATE			res_k2hstate;
 	DKCRES_STATE			res_state;
+	DKCRES_REPL_DEL			res_repl_del;
 }K2HDKC_ATTR_PACKED DKCCOM_ALL, *PDKCCOM_ALL;
 
 //---------------------------------------------------------
@@ -846,6 +870,7 @@ typedef union k2hdkc_com_all{
 #define	CVT_DKCCOM_CAS_INCDEC(pComAll)		(&(pComAll->com_cas_incdec))
 #define	CVT_DKCCOM_REPL_KEY(pComAll)		(&(pComAll->com_repl_key))
 #define	CVT_DKCCOM_K2HSTATE(pComAll)		(&(pComAll->com_k2hstate))
+#define	CVT_DKCCOM_REPL_DEL(pComAll)		(&(pComAll->com_repl_del))
 
 #define	CVT_DKCRES_GET(pComAll)				(&(pComAll->res_get))
 #define	CVT_DKCRES_GET_DIRECT(pComAll)		(&(pComAll->res_get_direct))
@@ -872,6 +897,7 @@ typedef union k2hdkc_com_all{
 #define	CVT_DKCRES_REPL_KEY(pComAll)		(&(pComAll->res_repl_key))
 #define	CVT_DKCRES_K2HSTATE(pComAll)		(&(pComAll->res_k2hstate))
 #define	CVT_DKCRES_STATE(pComAll)			(&(pComAll->res_state))
+#define	CVT_DKCRES_REPL_DEL(pComAll)		(&(pComAll->res_repl_del))
 
 DECL_EXTERN_C_END
 

--- a/lib/k2hdkccomutil.h
+++ b/lib/k2hdkccomutil.h
@@ -90,6 +90,7 @@
 #define GetCommonK2hdkcComReplKey(pk2hash, pchmcntrl, ...)		reinterpret_cast<K2hdkcComReplKey*>(	K2hdkcCommand::GetCommandSendObject(pk2hash, pchmcntrl, DKC_COM_REPL_KEY,	__VA_ARGS__))
 #define GetCommonK2hdkcComK2hState(pk2hash, pchmcntrl, ...)		reinterpret_cast<K2hdkcComK2hState*>(	K2hdkcCommand::GetCommandSendObject(pk2hash, pchmcntrl, DKC_COM_K2HSTATE,	__VA_ARGS__))
 #define GetCommonK2hdkcComState(pk2hash, pchmcntrl, ...)		reinterpret_cast<K2hdkcComState*>(		K2hdkcCommand::GetCommandSendObject(pk2hash, pchmcntrl, DKC_COM_STATE,		__VA_ARGS__))
+#define GetCommonK2hdkcComReplDel(pk2hash, pchmcntrl, ...)		reinterpret_cast<K2hdkcComReplDel*>(	K2hdkcCommand::GetCommandSendObject(pk2hash, pchmcntrl, DKC_COM_REPL_DEL,	__VA_ARGS__))
 
 //---------------------------------------------------------
 // Utility Macros for Class Factory
@@ -131,6 +132,7 @@
 #define	GetOtSlaveK2hdkcComReplKey(...)							reinterpret_cast<K2hdkcComReplKey*>(	K2hdkcCommand::GetSlaveCommandSendObject(DKC_COM_REPL_KEY,		__VA_ARGS__))
 #define	GetOtSlaveK2hdkcComK2hState(...)						reinterpret_cast<K2hdkcComK2hState*>(	K2hdkcCommand::GetSlaveCommandSendObject(DKC_COM_K2HSTATE,		__VA_ARGS__))
 #define	GetOtSlaveK2hdkcComState(...)							reinterpret_cast<K2hdkcComState*>(		K2hdkcCommand::GetSlaveCommandSendObject(DKC_COM_STATE,			__VA_ARGS__))
+#define	GetOtSlaveK2hdkcComReplDel(...)							reinterpret_cast<K2hdkcComReplDel*>(	K2hdkcCommand::GetSlaveCommandSendObject(DKC_COM_REPL_DEL,		__VA_ARGS__))
 
 //---------------------------------------------------------
 // Utility Macros for Class Factory
@@ -168,6 +170,7 @@
 #define	GetPmSlaveK2hdkcComReplKey(...)							reinterpret_cast<K2hdkcComReplKey*>(	K2hdkcSlave::GetSlaveCommandSendObject(DKC_COM_REPL_KEY,	__VA_ARGS__))
 #define	GetPmSlaveK2hdkcComK2hState(...)						reinterpret_cast<K2hdkcComK2hState*>(	K2hdkcSlave::GetSlaveCommandSendObject(DKC_COM_K2HSTATE,	__VA_ARGS__))
 #define	GetPmSlaveK2hdkcComState(...)							reinterpret_cast<K2hdkcComState*>(		K2hdkcSlave::GetSlaveCommandSendObject(DKC_COM_STATE,		__VA_ARGS__))
+#define	GetPmSlaveK2hdkcComReplDel(...)							reinterpret_cast<K2hdkcComReplDel*>(	K2hdkcSlave::GetSlaveCommandSendObject(DKC_COM_REPL_DEL,	__VA_ARGS__))
 
 #endif	// K2HDKCCOMUTIL_H
 

--- a/lib/k2hdkcslave.cc
+++ b/lib/k2hdkcslave.cc
@@ -97,7 +97,7 @@ bool K2hdkcSlave::Initialize(const char* config, short ctlport, const char* cuk,
 bool K2hdkcSlave::Clean(bool is_clean_bup)
 {
 	if(!IsInitialize()){
-		MSG_DKCPRN("This object does not initialized yet, so no not need to clean.");
+		//MSG_DKCPRN("This object does not initialized yet, so no not need to clean.");
 		return true;
 	}
 	if(IsOpen()){

--- a/src/k2hdkccntrl.cc
+++ b/src/k2hdkccntrl.cc
@@ -80,7 +80,8 @@ void K2hdkcCntrl::SigUsr2handler(int signum)
 void K2hdkcCntrl::SigHupHandler(int signum)
 {
 	if(SIGHUP == signum){
-		// Nothing to do now
+		// Same as SigExitHandler for break loop
+		K2hdkcCntrl::Get()->is_loop = false;
 	}
 }
 

--- a/src/k2hdkcmain.cc
+++ b/src/k2hdkcmain.cc
@@ -178,6 +178,10 @@ int main(int argc, char** argv)
 		SetK2hdkcDbgMode(dbgmode);
 	}
 
+	// Set chmpx/k2hash debug mode from environment
+	k2h_load_debug_env();
+	chmpx_load_debug_env();
+
 	// parameter - configuration file path
 	string	config;
 	if(!opts.Get(OPT_CONFPATH, config)){

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -358,7 +358,7 @@ if [ ${TEST_RESULT} -eq 0 -a "X${DO_INI_CONF}" = "Xyes" ]; then
 	(ps -p ${CHMPX_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${CHMPX_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${K2HDKC_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_LT_8021_PID}	> /dev/null 2>&1) && (kill -HUP ${K2HDKC_LT_8021_PID}	>> ${LOGFILE} 2>&1)
-	sleep 1
+	sleep 10
 	(ps -p ${CHMPX_8031_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8031_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${CHMPX_8027_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8027_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8027_PID}		> /dev/null 2>&1) && (kill -9 ${K2HDKC_8027_PID}		>> ${LOGFILE} 2>&1)
@@ -558,7 +558,7 @@ if [ ${TEST_RESULT} -eq 0 -a "X${DO_YAML_CONF}" = "Xyes" ]; then
 	(ps -p ${CHMPX_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${CHMPX_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${K2HDKC_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_LT_8021_PID}	> /dev/null 2>&1) && (kill -HUP ${K2HDKC_LT_8021_PID}	>> ${LOGFILE} 2>&1)
-	sleep 1
+	sleep 10
 	(ps -p ${CHMPX_8031_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8031_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${CHMPX_8027_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8027_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8027_PID}		> /dev/null 2>&1) && (kill -9 ${K2HDKC_8027_PID}		>> ${LOGFILE} 2>&1)
@@ -758,7 +758,7 @@ if [ ${TEST_RESULT} -eq 0 -a "X${DO_JSON_CONF}" = "Xyes" ]; then
 	(ps -p ${CHMPX_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${CHMPX_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${K2HDKC_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_LT_8021_PID}	> /dev/null 2>&1) && (kill -HUP ${K2HDKC_LT_8021_PID}	>> ${LOGFILE} 2>&1)
-	sleep 1
+	sleep 10
 	(ps -p ${CHMPX_8031_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8031_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${CHMPX_8027_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8027_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8027_PID}		> /dev/null 2>&1) && (kill -9 ${K2HDKC_8027_PID}		>> ${LOGFILE} 2>&1)
@@ -957,7 +957,7 @@ if [ ${TEST_RESULT} -eq 0 -a "X${DO_JSON_STRING}" = "Xyes" ]; then
 	(ps -p ${CHMPX_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${CHMPX_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${K2HDKC_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_LT_8021_PID}	> /dev/null 2>&1) && (kill -HUP ${K2HDKC_LT_8021_PID}	>> ${LOGFILE} 2>&1)
-	sleep 1
+	sleep 10
 	(ps -p ${CHMPX_8031_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8031_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${CHMPX_8027_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8027_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8027_PID}		> /dev/null 2>&1) && (kill -9 ${K2HDKC_8027_PID}		>> ${LOGFILE} 2>&1)
@@ -1156,7 +1156,7 @@ if [ ${TEST_RESULT} -eq 0 -a "X${DO_JSON_ENV}" = "Xyes" ]; then
 	(ps -p ${CHMPX_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${CHMPX_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${K2HDKC_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_LT_8021_PID}	> /dev/null 2>&1) && (kill -HUP ${K2HDKC_LT_8021_PID}	>> ${LOGFILE} 2>&1)
-	sleep 1
+	sleep 10
 	(ps -p ${CHMPX_8031_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8031_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${CHMPX_8027_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8027_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8027_PID}		> /dev/null 2>&1) && (kill -9 ${K2HDKC_8027_PID}		>> ${LOGFILE} 2>&1)
@@ -1365,7 +1365,7 @@ if [ ${TEST_RESULT} -eq 0 -a "X${DO_INI_CONF}" = "Xyes" ]; then
 	(ps -p ${CHMPX_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${CHMPX_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${K2HDKC_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_LT_8021_PID}	> /dev/null 2>&1) && (kill -HUP ${K2HDKC_LT_8021_PID}	>> ${LOGFILE} 2>&1)
-	sleep 1
+	sleep 10
 	(ps -p ${CHMPX_8031_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8031_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${CHMPX_8027_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8027_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8027_PID}		> /dev/null 2>&1) && (kill -9 ${K2HDKC_8027_PID}		>> ${LOGFILE} 2>&1)
@@ -1655,7 +1655,7 @@ elif [ ${TEST_RESULT} -eq 0 -a "X${DO_YAML_CONF}" = "Xyes" ]; then
 	(ps -p ${CHMPX_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${CHMPX_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${K2HDKC_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_LT_8021_PID}	> /dev/null 2>&1) && (kill -HUP ${K2HDKC_LT_8021_PID}	>> ${LOGFILE} 2>&1)
-	sleep 1
+	sleep 10
 	(ps -p ${CHMPX_8031_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8031_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${CHMPX_8027_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8027_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8027_PID}		> /dev/null 2>&1) && (kill -9 ${K2HDKC_8027_PID}		>> ${LOGFILE} 2>&1)
@@ -1946,7 +1946,7 @@ elif [ ${TEST_RESULT} -eq 0 -a "X${DO_JSON_CONF}" = "Xyes" ]; then
 	(ps -p ${CHMPX_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${CHMPX_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${K2HDKC_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_LT_8021_PID}	> /dev/null 2>&1) && (kill -HUP ${K2HDKC_LT_8021_PID}	>> ${LOGFILE} 2>&1)
-	sleep 1
+	sleep 10
 	(ps -p ${CHMPX_8031_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8031_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${CHMPX_8027_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8027_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8027_PID}		> /dev/null 2>&1) && (kill -9 ${K2HDKC_8027_PID}		>> ${LOGFILE} 2>&1)
@@ -2235,7 +2235,7 @@ elif [ ${TEST_RESULT} -eq 0 -a "X${DO_JSON_STRING}" = "Xyes" ]; then
 	(ps -p ${CHMPX_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${CHMPX_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${K2HDKC_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_LT_8021_PID}	> /dev/null 2>&1) && (kill -HUP ${K2HDKC_LT_8021_PID}	>> ${LOGFILE} 2>&1)
-	sleep 1
+	sleep 10
 	(ps -p ${CHMPX_8031_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8031_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${CHMPX_8027_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8027_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8027_PID}		> /dev/null 2>&1) && (kill -9 ${K2HDKC_8027_PID}		>> ${LOGFILE} 2>&1)
@@ -2524,7 +2524,7 @@ elif [ ${TEST_RESULT} -eq 0 -a "X${DO_JSON_ENV}" = "Xyes" ]; then
 	(ps -p ${CHMPX_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${CHMPX_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8021_PID}		> /dev/null 2>&1) && (kill -HUP ${K2HDKC_8021_PID}		>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_LT_8021_PID}	> /dev/null 2>&1) && (kill -HUP ${K2HDKC_LT_8021_PID}	>> ${LOGFILE} 2>&1)
-	sleep 1
+	sleep 10
 	(ps -p ${CHMPX_8031_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8031_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${CHMPX_8027_PID}		> /dev/null 2>&1) && (kill -9 ${CHMPX_8027_PID}			>> ${LOGFILE} 2>&1)
 	(ps -p ${K2HDKC_8027_PID}		> /dev/null 2>&1) && (kill -9 ${K2HDKC_8027_PID}		>> ${LOGFILE} 2>&1)


### PR DESCRIPTION
## Relevant Issue (if applicable)
https://github.com/yahoojapan/k2hash/pull/38
https://github.com/yahoojapan/chmpx/pull/42

## Details
### Key deletion replication
The key deletion was not replicated, but it was changed now to replicate to the complement node.
Also, if a key is deleted during some node down, k2hdkc creates a placeholder(expired key) so that the key deletion is replicated after that node is restarted.

### load k2hash/chmpx debug environment variables
Debug environment variables of k2hash and chmpx are loaded and reflected at startup.

### Handling of SIGHUP
SIGHUP was not handled, but it has been changed to terminate the process. It is as same as SIGTERM and SIGKILL.
