### PR TITLE
Updated files for release 0.9.30

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+k2hdkc (0.9.30) unstable; urgency=low
+
+  * Fixed a bug that replication of key deletion was not performed - #24
+  * Fixed dead loop in removing key with looping subkey - #23
+  * Fixed code for cppcheck 1.90 - #22
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Thu, 09 Apr 2020 10:00:18 +0900
+
 k2hdkc (0.9.29) unstable; urgency=low
 
   * Updated dependencies and codes with CHMPX code update - #18

--- a/buildutils/control.in
+++ b/buildutils/control.in
@@ -2,7 +2,7 @@ Source: @PACKAGE_NAME@
 Section: database
 Priority: optional
 Maintainer: @DEV_NAME@ <@DEV_EMAIL@>
-Build-Depends: @DEBHELPER_DEP@, k2hash-dev (>= 1.0.71), chmpx-dev (>= 1.0.73), libfullock-dev (>= 1.0.36), libyaml-dev
+Build-Depends: @DEBHELPER_DEP@, k2hash-dev (>= 1.0.74), chmpx-dev (>= 1.0.74), libfullock-dev (>= 1.0.36), libyaml-dev
 Depends: ${misc:Depends}
 Standards-Version: 3.9.8
 Homepage: https://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@
@@ -12,7 +12,7 @@ Vcs-Browser: https://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@
 Package: @PACKAGE_NAME@-dev
 Section: devel
 Architecture: amd64
-Depends: ${misc:Depends}, @PACKAGE_NAME@ (= ${binary:Version}), k2hash-dev (>= 1.0.71), chmpx-dev (>= 1.0.73), libfullock-dev (>= 1.0.36), libyaml-dev
+Depends: ${misc:Depends}, @PACKAGE_NAME@ (= ${binary:Version}), k2hash-dev (>= 1.0.74), chmpx-dev (>= 1.0.74), libfullock-dev (>= 1.0.36), libyaml-dev
 Description: @SHORTDESC@ (development)
  Development package for building with @PACKAGE_NAME@ shared library.
   This package has header files and symbols for it.
@@ -20,6 +20,6 @@ Description: @SHORTDESC@ (development)
 Package: @PACKAGE_NAME@
 Section: database
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, k2hash (>= 1.0.71), chmpx (>= 1.0.73), libfullock (>= 1.0.36)
+Depends: ${shlibs:Depends}, ${misc:Depends}, k2hash (>= 1.0.74), chmpx (>= 1.0.74), libfullock (>= 1.0.36)
 Description: @SHORTDESC@
 @DEBLONGDESC@

--- a/buildutils/k2hdkc.spec.in
+++ b/buildutils/k2hdkc.spec.in
@@ -47,8 +47,8 @@ License: @PKGLICENSE@
 @RPMPKG_GROUP@
 URL: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@
 Source0: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@/archive/%{gittag}/%{name}-%{version}.tar.gz
-Requires: libfullock%{?_isa} >= 1.0.36, k2hash%{?_isa} >= 1.0.71, chmpx%{?_isa} >= 1.0.73
-BuildRequires: git-core gcc-c++ make libtool libfullock-devel >= 1.0.36, k2hash-devel >= 1.0.71, chmpx-devel >= 1.0.73, libyaml-devel
+Requires: libfullock%{?_isa} >= 1.0.36, k2hash%{?_isa} >= 1.0.74, chmpx%{?_isa} >= 1.0.74
+BuildRequires: git-core gcc-c++ make libtool libfullock-devel >= 1.0.36, k2hash-devel >= 1.0.74, chmpx-devel >= 1.0.74, libyaml-devel
 
 %description
 @LONGDESC@
@@ -99,7 +99,7 @@ rm -rf %{buildroot}
 #
 %package devel
 Summary: @SHORTDESC@ (development)
-Requires: %{name}%{?_isa} = %{version}-%{release}, libfullock-devel%{?_isa} >= 1.0.36, k2hash-devel%{?_isa} >= 1.0.71, chmpx-devel%{?_isa} >= 1.0.73, libyaml-devel
+Requires: %{name}%{?_isa} = %{version}-%{release}, libfullock-devel%{?_isa} >= 1.0.36, k2hash-devel%{?_isa} >= 1.0.74, chmpx-devel%{?_isa} >= 1.0.74, libyaml-devel
 
 %description devel
 Development package for building with @PACKAGE_NAME@ shared library.

--- a/configure.ac
+++ b/configure.ac
@@ -130,8 +130,8 @@ AC_ARG_ENABLE(check-depend-libs,
 )
 AS_IF([test ${check_depend_libs} = 1], [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no)])
 AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.36], [], [AC_MSG_ERROR(not found libfullock package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.71], [], [AC_MSG_ERROR(not found k2hash package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.73], [], [AC_MSG_ERROR(not found chmpx package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.74], [], [AC_MSG_ERROR(not found k2hash package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.74], [], [AC_MSG_ERROR(not found chmpx package)])])
 
 #
 # CFLAGS/CXXFLAGS


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 0.9.29 to 0.9.30
- Fixed a bug that replication of key deletion was not performed - #24
- Fixed dead loop in removing key with looping subkey - #23
- Fixed code for cppcheck 1.90 - #22

