### PR TITLE
Drops Fedora28 and CentOS6.x from our support OS

### DIFF
--- a/build.md
+++ b/build.md
@@ -42,7 +42,7 @@ This section instructs how to install each dependent library and the header file
 
 **Note**: Skip reading this section if you have installed each dependent library and the header files from [GitHub](https://github.com/yahoojapan) in the previous section.
 
-For DebianStretch or Ubuntu(Bionic Beaver) users, follow the steps below:
+For recent Debian-based Linux distributions users, follow the steps below:
 ```bash
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -53,7 +53,18 @@ $ sudo apt-get install autoconf autotools-dev gcc g++ make gdb libtool pkg-confi
 $ sudo apt-get install git -y
 ```
 
-For Fedora28 or CentOS7.x(6.x) users, follow the steps below:
+For users who use supported Fedora other than latest version, follow the steps below:
+```bash
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh \
+    | sudo bash
+$ sudo dnf install autoconf automake gcc gcc-c++ gdb make libtool pkgconfig \
+    libyaml-devel libfullock-devel k2hash-devel chmpx-devel -y
+$ sudo dnf install git -y
+```
+
+For other recent RPM-based Linux distributions users, follow the steps below:
 ```bash
 $ sudo yum makecache
 $ sudo yum install curl -y

--- a/buildja.md
+++ b/buildja.md
@@ -44,7 +44,7 @@ next_string: Developer
 
 注：前のセクションで[GitHub](https://github.com/yahoojapan)から各依存ライブラリとヘッダーファイルをインストールした場合は、このセクションを読み飛ばしてください。
 
-DebianStretchまたはUbuntu（Bionic Beaver）をお使いの場合は、以下の手順に従ってください。
+最近のDebianベースLinuxの利用者は、以下の手順に従ってください。
 
 ```
 $ sudo apt-get update -y
@@ -56,7 +56,19 @@ $ sudo apt-get install autoconf autotools-dev gcc g++ make gdb libtool pkg-confi
 $ sudo apt-get install git -y
 ```
 
-Fedora28またはCentOS7.x（6.x）ユーザーの場合は、以下の手順に従ってください。
+Fedoraの利用者は、以下の手順に従ってください。
+
+```
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh \
+    | sudo bash
+$ sudo dnf install autoconf automake gcc gcc-c++ gdb make libtool pkgconfig \
+    libyaml-devel libfullock-devel k2hash-devel chmpx-devel -y
+$ sudo dnf install git -y
+```
+
+その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。
 
 ```
 $ sudo yum makecache

--- a/feature.md
+++ b/feature.md
@@ -16,6 +16,9 @@ next_string: Usage
 # Feature
 **K2HDKC** is a highly available and scalable distributed KVS clustering system and also feature many useful and unique functions.
 
+## Flexible installation
+We provide suitable K2HDKC installation for your OS. If you use Ubuntu, CentOS, Fedora or Debian, you can easily install it from [packagecloud.io] (https://packagecloud.io/antpickax/stable). Even if you use none of them, you can use it by [Build] (https://k2hdkc.antpick.ax/build.html) by yourself.
+
 ## Automated data synchronization between server nodes.
 - Automatic Merging  
 After recovering from transient node failures, data will be relocated automatically.

--- a/featureja.md
+++ b/featureja.md
@@ -16,6 +16,9 @@ next_string: Usage
 # 特徴
 **K2HDKC**は、高可用性でスケーラブルな分散型KVSクラスタリングシステムであり、多くの有用でユニークな機能も備えています。
 
+## 柔軟なインストール
+K2HDKCは、あなたのOSに応じて、柔軟にインストールが可能です。あなたのOSが、Ubuntu、CentOS、Fedora、Debianなら、[packagecloud.io](https://packagecloud.io/antpickax/stable)からソースコードをビルドすることなく、簡単にインストールできます。それ以外のOSであっても、自身で[ビルド](https://k2hdkc.antpick.ax/buildja.html)して使うことができます。
+
 ## サーバーノード間の自動データ同期
 - 自動マージ  
 一時的なノードの障害から回復した後、データは自動的に再配置されます。

--- a/usage.md
+++ b/usage.md
@@ -29,7 +29,7 @@ The **K2HDKC** publishes [packages](https://packagecloud.io/app/antpickax/stable
 The package of the **K2HDKC** is released in the form of Debian package, RPM package.  
 Since the installation method differs depending on your OS, please check the following procedure and install it.  
 
-#### Debian(Stretch) / Ubuntu(Bionic Beaver)
+#### For recent Debian-based Linux distributions users, follow the steps below:
 ```
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -41,7 +41,19 @@ To install the developer package, please install the following package.
 $ sudo apt-get install k2hdkc-dev
 ```
 
-#### Fedora28 / CentOS7.x(6.x)
+#### For users who use supported Fedora other than latest version, follow the steps below:
+```
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh | sudo bash
+$ sudo dnf install k2hdkc
+```
+To install the developer package, please install the following package.
+```
+$ sudo dnf install k2hdkc-devel
+```
+
+#### For other recent RPM-based Linux distributions users, follow the steps below:
 ```
 $ sudo yum makecache
 $ sudo yum install curl -y

--- a/usageja.md
+++ b/usageja.md
@@ -29,7 +29,7 @@ next_string: Build
 **K2HDKC** のパッケージは、Debianパッケージ、RPMパッケージの形式で公開しています。  
 お使いのOSによりインストール方法が異なりますので、以下の手順を確認してインストールしてください。  
 
-#### Debian(Stretch) / Ubuntu(Bionic Beaver)
+#### 最近のDebianベースLinuxの利用者は、以下の手順に従ってください。
 ```
 $ sudo apt-get update -y
 $ sudo apt-get install curl -y
@@ -41,7 +41,19 @@ $ sudo apt-get install k2hdkc
 $ sudo apt-get install k2hdkc-dev
 ```
 
-#### Fedora28 / CentOS7.x(6.x)
+#### Fedoraの利用者は、以下の手順に従ってください。
+```
+$ sudo dnf makecache
+$ sudo dnf install curl -y
+$ curl -s https://packagecloud.io/install/repositories/antpickax/stable/script.rpm.sh | sudo bash
+$ sudo dnf install k2hdkc
+```
+開発者向けパッケージをインストールする場合は、以下のパッケージをインストールしてください。
+```
+$ sudo dnf install k2hdkc-devel
+```
+
+#### その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。
 ```
 $ sudo yum makecache
 $ sudo yum install curl -y


### PR DESCRIPTION
## Relevant Issue (if applicable)
N/A

## Details
This PR removes unsupported OS descrptions from the manuals.