### PR TITLE
Enhanced confirmation of wait process for k2hdkc.service

### DIFF
--- a/buildutils/k2hdkc-service-helper
+++ b/buildutils/k2hdkc-service-helper
@@ -436,17 +436,31 @@ wait_process_up()
 					prn_info "Found PID file(${_WAITPROC_PID_FILE}) but PID(${_WAITPROC_PID}) is not running."
 				else
 					#
-					# OK
+					# OK(single checking)
 					#
-					prn_info "PID(${_WAITPROC_PID}) process running."
+					if [ ${_WAITPROC_AFTER_SEC} -le 0 ]; then
+						prn_info "PID(${_WAITPROC_PID}) process running."
+						return 0
+					fi
 
 					#
 					# Sleep
 					#
-					if [ ${_WAITPROC_AFTER_SEC} -gt 0 ]; then
-						sleep ${_WAITPROC_AFTER_SEC}
+					sleep ${_WAITPROC_AFTER_SEC}
+
+					#
+					# Re-check process
+					#
+					ps -p ${_WAITPROC_PID} | grep -v PID | grep -v [Dd]efunct >/dev/null 2>&1
+					if [ $? -ne 0 ]; then
+						prn_info "Found PID file(${_WAITPROC_PID_FILE}) but PID(${_WAITPROC_PID}) is not running."
+					else
+						#
+						# OK(double checking)
+						#
+						prn_info "PID(${_WAITPROC_PID}) process running."
+						return 0
 					fi
-					return 0
 				fi
 			fi
 		else


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
In k2hdkc.service(k2hdkc-service-helper), there is a process wait process.
This standby process has been enhanced so that confirmation of the start of other processes can be double-checked.

