### PR TITLE
Bypass a specific version of cppcheck due to poor performance

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,8 +29,37 @@ CPPCHECK_OPT=	--quiet \
 				--enable=warning,style,information,missingInclude
 CPPCHECK_IGN=
 
+# [NOTE]
+# Building chmpx on Github Actions(CI) is running in several OS.
+# Depending on the OS(CentOS, ubuntu, debian, fedora), different
+# cppcheck versions are installed. Certain versions of cppcheck
+# are incompatible with the chmpx template source code and are
+# very poor performance on the VM or container(CI).
+# In the problematic version, cppcheck runs very slowly. To avoid
+# this we skip only specific versions of cppcheck. Even if we
+# skip a specific version of the cppcheck, it will be tested
+# with a combination of other versions and OS.
+# When the process runs on Github Actions, the CI environment is
+# set true.
+# 
+# Currently, old debian and centos use cppcheck 1.7x(or 1.6x),
+# there is a problem with these old version and skipping these.
+# If the other will support 1.8x or later versions in the
+# future, this skipped process will be unnecessary.
+#
+CPPCHECK_NGVER=	-e 1\\.7 -e 1\\.6
+
 cppcheck:
-	$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_IGN) $(SUBDIRS)
+	echo "$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_IGN) $(SUBDIRS)"
+	if test "X$$CI" = "Xtrue"; then \
+		if ($(CPPCHECK_CMD) --version | grep $(CPPCHECK_NGVER)) >/dev/null 2>&1; then \
+			echo " --> Skip, because this old $(CPPCHECK_CMD) version is very poor performance on VM(CI)"; \
+		else \
+			$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_IGN) $(SUBDIRS); \
+		fi; \
+	else \
+		$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_IGN) $(SUBDIRS); \
+	fi
 
 #
 # VIM modelines


### PR DESCRIPTION
#### Relevant Issue (if applicable)
n/a

#### Details
Performance drops significantly with cppcheck 1.6x and 1.7x.
(This is probably due to the parsing part of the template source code, but older versions will slow down performance.)
TravisCI dealt with it, but GithubActions didn't, so I added the corresponding code.
