### PR TITLE
Updated files for release 0.9.35

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+k2hdkc (0.9.35) unstable; urgency=low
+
+  * Fixed an issue with stopping service subprocesses - #40
+  * Bypass a specific version of cppcheck due to poor performance - #39
+
+ -- Takeshi Nakatani <ggtakec@gmail.com>  Thu, 04 Feb 2021 15:29:56 +0900
+
 k2hdkc (0.9.34) unstable; urgency=low
 
   * Enhanced confirmation of wait process for k2hdkc.service - #37


### PR DESCRIPTION
## Relevant Issue (if applicable)
n/a

## Details
### Changes from 0.9.34 to 0.9.35
- Fixed an issue with stopping service subprocesses - #40
- Bypass a specific version of cppcheck due to poor performance - #39

