### PR TITLE
Enabled external customization of configure.ac and fixed for building

### DIFF
--- a/.github/workflows/ostypevars.sh
+++ b/.github/workflows/ostypevars.sh
@@ -146,6 +146,11 @@ elif [ "X${CI_OSTYPE}" = "Xcentos:8" -o "X${CI_OSTYPE}" = "Xcentos:centos8" ]; t
 	PKG_EXT="rpm"
 	IS_OS_CENTOS=1
 
+	#
+	# Change mirrorlist
+	#
+	sed -i -e 's|^mirrorlist|#mirrorlist|g' -e 's|^#baseurl=http://mirror|baseurl=http://vault|g' /etc/yum.repos.d/CentOS-*repo
+
 	# [NOTE]
 	# For CentOS8, installing libyaml-devel from PowerTools( PwoerTools -> powertools at 2020/12 )
 	#

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,7 @@
 
 SUBDIRS=docs lib src tests buildutils
 
-EXTRA_DIST=RELEASE_VERSION
+EXTRA_DIST=RELEASE_VERSION @CONFIGURECUSTOM@
 
 CPPCHECK_CMD=	cppcheck
 CPPCHECK_OPT=	--quiet \
@@ -62,7 +62,10 @@ cppcheck:
 	fi
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #

--- a/buildutils/Makefile.am
+++ b/buildutils/Makefile.am
@@ -38,7 +38,10 @@ EXTRA_DIST =make_variables.sh \
 			override.conf.k2hdkc_example
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #

--- a/buildutils/control.in
+++ b/buildutils/control.in
@@ -2,7 +2,7 @@ Source: @PACKAGE_NAME@
 Section: database
 Priority: optional
 Maintainer: @DEV_NAME@ <@DEV_EMAIL@>
-Build-Depends: @DEBHELPER_DEP@, dh-systemd (>= 1.5), k2hash-dev (>= 1.0.74), chmpx-dev (>= 1.0.74), libfullock-dev (>= 1.0.36), libyaml-dev
+Build-Depends: @DEBHELPER_DEP@, k2hash-dev (>= 1.0.74), chmpx-dev (>= 1.0.74), libfullock-dev (>= 1.0.36), libyaml-dev
 Standards-Version: 3.9.8
 Homepage: https://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@
 Vcs-Git: git://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@.git

--- a/configure.ac
+++ b/configure.ac
@@ -76,15 +76,40 @@ AC_CHECK_HEADERS([limits.h sys/time.h termios.h])
 AC_CONFIG_MACRO_DIR([m4])
 
 #
+# Load customizable variables
+#
+AC_CHECK_FILE([configure.custom],
+	[
+		configure_custom_file="configure.custom"
+		custom_git_domain="$(grep '^\s*GIT_DOMAIN\s*=' configure.custom | sed -e 's|^\s*GIT_DOMAIN\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_org="$(grep '^\s*GIT_ORG\s*=' configure.custom | sed -e 's|^\s*GIT_ORG\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_repo="$(grep '^\s*GIT_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_git_endpoint="$(grep '^\s*GIT_EP_V3_REPO\s*=' configure.custom | sed -e 's|^\s*GIT_EP_V3_REPO\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_email="$(grep '^\s*DEV_EMAIL\s*=' configure.custom | sed -e 's|^\s*DEV_EMAIL\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+		custom_dev_name="$(grep '^\s*DEB_NAME\s*=' configure.custom | sed -e 's|^\s*DEB_NAME\s*=\s*||g' -e 's|^\s*||g' -e 's|\s*$||g')"
+	],
+	[
+		configure_custom_file=""
+		custom_git_domain="github.com"
+		custom_git_org="yahoojapan"
+		custom_git_repo="k2hdkc"
+		custom_git_endpoint="https://api.github.com/repos/"
+		custom_dev_email="antpickax-support@mail.yahoo.co.jp"
+		custom_dev_name="K2HASH_DEVELOPER"
+	]
+)
+
+#
 # Symbols for buildutils
 #
-AC_SUBST([GIT_DOMAIN], "github.com")
-AC_SUBST([GIT_ORG], "yahoojapan")
-AC_SUBST([GIT_REPO], "k2hdkc")
-AC_SUBST([CURRENTREV], "`$(pwd)/buildutils/make_commit_hash.sh -o yahoojapan -r k2hdkc -short`")
-AC_SUBST([DEV_EMAIL], "`echo ${DEBEMAIL:-antpickax-support@mail.yahoo.co.jp}`")
-AC_SUBST([DEV_NAME], "`echo ${DEBFULLNAME:-K2HASH_DEVELOPER}`")
-
+AC_SUBST([CONFIGURECUSTOM], "${configure_custom_file}")
+AC_SUBST([GIT_DOMAIN], "${custom_git_domain}")
+AC_SUBST([GIT_ORG], "${custom_git_org}")
+AC_SUBST([GIT_REPO], "${custom_git_repo}")
+AC_SUBST([CURRENTREV], "$($(pwd)/buildutils/make_commit_hash.sh -o "${custom_git_org}" -r "${custom_git_repo}" -ep "${custom_git_endpoint}" -short)")
+AC_SUBST([DEV_EMAIL], "$(echo ${DEBEMAIL:-"${custom_dev_email}"})")
+AC_SUBST([DEV_NAME], "$(echo ${DEBFULLNAME:-"${custom_dev_name}"})")
+#
 AC_SUBST([RPMCHANGELOG], "`$(pwd)/buildutils/make_rpm_changelog.sh $(pwd)/ChangeLog`")
 AC_SUBST([SHORTDESC], "`$(pwd)/buildutils/make_description.sh $(pwd)/docs/k2hdkc.1 -short`")
 AC_SUBST([LONGDESC], "`$(pwd)/buildutils/make_description.sh $(pwd)/docs/k2hdkc.1 -long`")
@@ -157,7 +182,10 @@ AC_CONFIG_FILES([Makefile
 AC_OUTPUT
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -103,8 +103,15 @@ libk2hdkc_la_LDFLAGS= -version-info $(LIB_VERSION_INFO)
 libk2hdkc_la_LIBADD	= $(fullock_LIBS) $(k2hash_LIBS) $(chmpx_LIBS)
 
 ACLOCAL_AMFLAGS		= -I m4
-AM_CFLAGS			= $(fullock_CFLAGS) $(k2hash_CFLAGS) $(chmpx_CFLAGS)
-AM_CPPFLAGS			= $(fullock_CFLAGS) $(k2hash_CFLAGS) $(chmpx_CFLAGS)
+
+# [NOTE]
+# "-Waddress-of-packed-member" optsion was introduced by default
+# from GCC 9.
+# Knowing that packed structure is CPU architecture dependent,
+# this program ignores this warning.
+#
+AM_CFLAGS			= $(fullock_CFLAGS) $(k2hash_CFLAGS) $(chmpx_CFLAGS) -Wno-address-of-packed-member
+AM_CPPFLAGS			= $(fullock_CFLAGS) $(k2hash_CFLAGS) $(chmpx_CFLAGS) -Wno-address-of-packed-member
 
 ### version(commit hash)
 .PHONY:	k2hdkcxversion
@@ -113,7 +120,10 @@ k2hdkcversion.cc:	k2hdkcxversion
 	@../buildutils/make_commit_hash_source.sh k2hdkcversion.cc k2hdkc_commit_hash
 
 #
-# VIM modelines
-#
-# vim:set ts=4 fenc=utf-8:
+# Local variables:
+# tab-width: 4
+# c-basic-offset: 4
+# End:
+# vim600: noexpandtab sw=4 ts=4 fdm=marker
+# vim<600: noexpandtab sw=4 ts=4
 #

--- a/lib/k2hdkccombase.cc
+++ b/lib/k2hdkccombase.cc
@@ -721,7 +721,6 @@ bool K2hdkcCommand::Clean(void)
 {
 	bool	result	= true;
 	pK2hObj			= NULL;
-	pChmObj			= NULL;
 
 	// free
 	DKC_FREE(pRcvComAll);
@@ -741,6 +740,7 @@ bool K2hdkcCommand::Clean(void)
 			}
 		}
 	}
+	pChmObj = NULL;
 	CleanSlave();
 
 	SendHash	= 0L;

--- a/lib/k2hdkccomnum.cc
+++ b/lib/k2hdkccomnum.cc
@@ -19,6 +19,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <time.h>
 
 #include <k2hash/k2hutil.h>
 

--- a/src/k2hdkccntrl.cc
+++ b/src/k2hdkccntrl.cc
@@ -26,6 +26,7 @@
 #include "k2hdkccommon.h"
 #include "k2hdkccntrl.h"
 #include "k2hdkccombase.h"
+#include "k2hdkcutil.h"
 #include "k2hdkcdbg.h"
 
 using namespace	std;
@@ -649,6 +650,9 @@ K2hdkcCommand* K2hdkcCntrl::FindWaitCommandObject(uint64_t comnum, dkccom_type_t
 				// cppcheck-suppress unmatchedSuppression
 				// cppcheck-suppress stlSize
 				if(0 == pcommap->size()){
+					// [FIXME] by cppcheck 2.7
+					// cppcheck-suppress unmatchedSuppression
+					// cppcheck-suppress unknownMacro
 					DKC_DELETE(pcommap)
 					waitmap.erase(iternum);
 				}


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
- Enabled to customize variables in configure.ac  
If the configure.custom file exists, it will be loaded.  
(currently unused but added to increase availability)
- Fixed an error output by cppcheck 2.7(etc)
- Fixed CentOS 8 build failing.  
It was caused by changing the mirror, so I fixed it.
- Ignore address-of-packed-member warning by GCC 9 
