### PR TITLE
Fixed errors reported by cppcheck 2.9

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,8 @@ CPPCHECK_OPT=	--quiet \
 				-j 4 \
 				--std=c++03 \
 				--xml \
-				--enable=warning,style,information,missingInclude
+				--enable=warning,style,information,missingInclude \
+				--cppcheck-build-dir=/tmp/cppcheck
 CPPCHECK_IGN=
 
 # [NOTE]
@@ -47,18 +48,19 @@ CPPCHECK_IGN=
 # If the other will support 1.8x or later versions in the
 # future, this skipped process will be unnecessary.
 #
-CPPCHECK_NGVER=	-e 1\\.7 -e 1\\.6
+CPPCHECK_NGVER=	-e \^1\\.7 -e \^1\\.6
 
 cppcheck:
-	echo "$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_IGN) $(SUBDIRS)"
-	if test "X$$CI" = "Xtrue"; then \
-		if ($(CPPCHECK_CMD) --version | grep $(CPPCHECK_NGVER)) >/dev/null 2>&1; then \
-			echo " --> Skip, because this old $(CPPCHECK_CMD) version is very poor performance on VM(CI)"; \
-		else \
-			$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_IGN) $(SUBDIRS); \
-		fi; \
+	echo "$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_DEF) $(CPPCHECK_IGN) $(SUBDIRS)"
+	if ($(CPPCHECK_CMD) --version | sed -e 's|Cppcheck[[:space:]]*||gi' | grep -q $(CPPCHECK_NGVER)); then \
+		echo " --> Skip, because this old $(CPPCHECK_CMD) version is very poor performance on VM(CI)"; \
 	else \
-		$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_IGN) $(SUBDIRS); \
+		if [ -d /tmp/cppcheck ]; then \
+			rm -rf /tmp/cppcheck; \
+		fi; \
+		mkdir /tmp/cppcheck; \
+		$(CPPCHECK_CMD) $(CPPCHECK_OPT) $(CPPCHECK_DEF) $(CPPCHECK_IGN) $(SUBDIRS); \
+		rm -rf /tmp/cppcheck; \
 	fi
 
 #

--- a/lib/k2hdkccomaddsubkey.h
+++ b/lib/k2hdkccomaddsubkey.h
@@ -39,7 +39,7 @@ class K2hdkcComAddSubkey : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComAddSubkey(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComAddSubkey(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComAddSubkey(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomaddsubkeys.h
+++ b/lib/k2hdkccomaddsubkeys.h
@@ -38,7 +38,7 @@ class K2hdkcComAddSubkeys : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComAddSubkeys(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComAddSubkeys(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComAddSubkeys(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccombase.h
+++ b/lib/k2hdkccombase.h
@@ -114,7 +114,7 @@ class K2hdkcCommand
 		static K2hdkcCommand* GetCommandSendObject(K2HShm* pk2hash, ChmCntrl* pchmcntrl, dkccom_type_t comtype, msgid_t msgid = CHM_INVALID_MSGID, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		static K2hdkcCommand* GetSlaveCommandSendObject(dkccom_type_t comtype, const char* config, short ctlport = CHM_INVALID_PORT, const char* cuk = NULL, bool is_auto_rejoin = false, bool no_giveup_rejoin = false, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER);
 
-		K2hdkcCommand(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false, dkccom_type_t comtype = DKC_COM_UNKNOWN);
+		explicit K2hdkcCommand(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false, dkccom_type_t comtype = DKC_COM_UNKNOWN);
 		virtual ~K2hdkcCommand(void);
 
 		// parameters for command

--- a/lib/k2hdkccomcasget.h
+++ b/lib/k2hdkccomcasget.h
@@ -41,7 +41,7 @@ class K2hdkcComCasGet : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComCasGet(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = false, bool is_wait_on_server = false);
+		explicit K2hdkcComCasGet(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = false, bool is_wait_on_server = false);
 		virtual ~K2hdkcComCasGet(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomcasincdec.h
+++ b/lib/k2hdkccomcasincdec.h
@@ -38,7 +38,7 @@ class K2hdkcComCasIncDec : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComCasIncDec(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComCasIncDec(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComCasIncDec(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomcasinit.h
+++ b/lib/k2hdkccomcasinit.h
@@ -38,7 +38,7 @@ class K2hdkcComCasInit : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComCasInit(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComCasInit(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComCasInit(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomcasset.h
+++ b/lib/k2hdkccomcasset.h
@@ -38,7 +38,7 @@ class K2hdkcComCasSet : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComCasSet(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComCasSet(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComCasSet(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomdel.h
+++ b/lib/k2hdkccomdel.h
@@ -41,7 +41,7 @@ class K2hdkcComDel : public K2hdkcCommand
 		bool IsAllNodesSafe(void);
 
 	public:
-		K2hdkcComDel(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComDel(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComDel(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomdelsubkey.h
+++ b/lib/k2hdkccomdelsubkey.h
@@ -39,7 +39,7 @@ class K2hdkcComDelSubkey : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComDelSubkey(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComDelSubkey(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComDelSubkey(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomdelsubkeys.h
+++ b/lib/k2hdkccomdelsubkeys.h
@@ -38,7 +38,7 @@ class K2hdkcComDelSubkeys : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComDelSubkeys(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComDelSubkeys(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComDelSubkeys(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomget.h
+++ b/lib/k2hdkccomget.h
@@ -38,7 +38,7 @@ class K2hdkcComGet : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComGet(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = false, bool is_wait_on_server = false);
+		explicit K2hdkcComGet(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = false, bool is_wait_on_server = false);
 		virtual ~K2hdkcComGet(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomgetattr.h
+++ b/lib/k2hdkccomgetattr.h
@@ -38,7 +38,7 @@ class K2hdkcComGetAttr : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComGetAttr(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = false, bool is_wait_on_server = false);
+		explicit K2hdkcComGetAttr(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = false, bool is_wait_on_server = false);
 		virtual ~K2hdkcComGetAttr(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomgetattrs.h
+++ b/lib/k2hdkccomgetattrs.h
@@ -38,7 +38,7 @@ class K2hdkcComGetAttrs : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComGetAttrs(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = false, bool is_wait_on_server = false);
+		explicit K2hdkcComGetAttrs(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = false, bool is_wait_on_server = false);
 		virtual ~K2hdkcComGetAttrs(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomgetdirect.h
+++ b/lib/k2hdkccomgetdirect.h
@@ -38,7 +38,7 @@ class K2hdkcComGetDirect : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComGetDirect(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComGetDirect(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComGetDirect(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomgetsubkeys.h
+++ b/lib/k2hdkccomgetsubkeys.h
@@ -38,7 +38,7 @@ class K2hdkcComGetSubkeys : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComGetSubkeys(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = false, bool is_wait_on_server = false);
+		explicit K2hdkcComGetSubkeys(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = false, bool is_wait_on_server = false);
 		virtual ~K2hdkcComGetSubkeys(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomk2hstate.h
+++ b/lib/k2hdkccomk2hstate.h
@@ -38,7 +38,7 @@ class K2hdkcComK2hState : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComK2hState(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = false, bool is_wait_on_server = false);
+		explicit K2hdkcComK2hState(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = false, bool is_wait_on_server = false);
 		virtual ~K2hdkcComK2hState(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomqdel.h
+++ b/lib/k2hdkccomqdel.h
@@ -42,7 +42,7 @@ class K2hdkcComQDel : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComQDel(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComQDel(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComQDel(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomqpop.h
+++ b/lib/k2hdkccomqpop.h
@@ -44,7 +44,7 @@ class K2hdkcComQPop : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComQPop(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComQPop(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComQPop(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomqpush.h
+++ b/lib/k2hdkccomqpush.h
@@ -41,7 +41,7 @@ class K2hdkcComQPush : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComQPush(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComQPush(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComQPush(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomren.h
+++ b/lib/k2hdkccomren.h
@@ -38,7 +38,7 @@ class K2hdkcComRen : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComRen(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComRen(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComRen(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomrepldel.h
+++ b/lib/k2hdkccomrepldel.h
@@ -38,7 +38,7 @@ class K2hdkcComReplDel : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComReplDel(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComReplDel(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComReplDel(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomreplkey.h
+++ b/lib/k2hdkccomreplkey.h
@@ -38,7 +38,7 @@ class K2hdkcComReplKey : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComReplKey(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComReplKey(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComReplKey(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomset.h
+++ b/lib/k2hdkccomset.h
@@ -41,7 +41,7 @@ class K2hdkcComSet : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComSet(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComSet(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComSet(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomsetall.h
+++ b/lib/k2hdkccomsetall.h
@@ -38,7 +38,7 @@ class K2hdkcComSetAll : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComSetAll(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComSetAll(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComSetAll(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomsetdirect.h
+++ b/lib/k2hdkccomsetdirect.h
@@ -38,7 +38,7 @@ class K2hdkcComSetDirect : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComSetDirect(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComSetDirect(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComSetDirect(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomsetsubkeys.h
+++ b/lib/k2hdkccomsetsubkeys.h
@@ -38,7 +38,7 @@ class K2hdkcComSetSubkeys : public K2hdkcCommand
 		virtual void RawDumpComAll(const PDKCCOM_ALL pComAll) const;
 
 	public:
-		K2hdkcComSetSubkeys(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
+		explicit K2hdkcComSetSubkeys(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = true, bool is_wait_on_server = false);
 		virtual ~K2hdkcComSetSubkeys(void);
 
 		virtual bool CommandProcessing(void);

--- a/lib/k2hdkccomstate.h
+++ b/lib/k2hdkccomstate.h
@@ -47,7 +47,7 @@ class K2hdkcComState : public K2hdkcCommand
 		size_t GetServerNodeMapList(dkcchmpxhashmap_t& idhashmap);
 
 	public:
-		K2hdkcComState(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = false, bool is_wait_on_server = false);
+		explicit K2hdkcComState(K2HShm* pk2hash = NULL, ChmCntrl* pchmcntrl = NULL, uint64_t comnum = K2hdkcComNumber::INIT_NUMBER, bool without_self = true, bool is_routing_on_server = false, bool is_wait_on_server = false);
 		virtual ~K2hdkcComState(void);
 
 		virtual bool CommandProcessing(void);

--- a/src/k2hdkcopts.h
+++ b/src/k2hdkcopts.h
@@ -31,7 +31,7 @@ class K2hdkcOpts
 		strlstmap_t	optmap;
 
 	public:
-		K2hdkcOpts(int argc = 0, char** argv = NULL);
+		explicit K2hdkcOpts(int argc = 0, char** argv = NULL);
 		virtual ~K2hdkcOpts(void);
 
 		bool Initialize(int argc, char** argv);

--- a/tests/k2hdkclinetool.cc
+++ b/tests/k2hdkclinetool.cc
@@ -1295,9 +1295,9 @@ static bool BinaryDumpUtility(const char* prefix, const unsigned char* value, si
 	}
 
 	string	output;
-	string	line;
 	size_t	restcnt = vallen;
 	for(size_t pos = 0; pos < vallen; pos += BINARY_DUMP_BYTE_SIZE){
+		string	line;
 		if(0 == pos){
 			output += strpref;
 		}else{
@@ -2428,8 +2428,8 @@ static bool FillCommand(k2hdkc_chmpx_h chmpxhandle, params_t& params)
 	}
 
 	// do command
-	string	strFillKey;
 	for(int cnt = 0; cnt < FillCount; ++cnt){
+		string	strFillKey;
 		strFillKey = strKey + string("-") + to_string(cnt);
 		if(!RawSetCommand(chmpxhandle, reinterpret_cast<const unsigned char*>(strFillKey.c_str()), strFillKey.length() + 1, (strValue.empty() ? NULL : reinterpret_cast<const unsigned char*>(strValue.c_str())), (strValue.empty() ? 0 : (strValue.length() + 1)), is_rmsub, is_rmsublist, is_noattr, (PassPhrase.empty() ? NULL : PassPhrase.c_str()), (-1 == Expire ? NULL : &Expire))){
 			ERR("Something internal error occurred during setting key and value.");
@@ -2478,8 +2478,8 @@ static bool FillSubCommand(k2hdkc_chmpx_h chmpxhandle, params_t& params)
 	}
 
 	// do command
-	string	strFillKey;
 	for(int cnt = 0; cnt < FillCount; ++cnt){
+		string	strFillKey;
 		strFillKey = strSubKey + string("-") + to_string(cnt);
 		if(!RawSetSubkeyCommand(chmpxhandle, reinterpret_cast<const unsigned char*>(strParentKey.c_str()), strParentKey.length() + 1, reinterpret_cast<const unsigned char*>(strFillKey.c_str()), strFillKey.length() + 1, (strValue.empty() ? NULL : reinterpret_cast<const unsigned char*>(strValue.c_str())), (strValue.empty() ? 0 : (strValue.length() + 1)), is_noattr, (PassPhrase.empty() ? NULL : PassPhrase.c_str()), (-1 == Expire ? NULL : &Expire))){
 			ERR("Something internal error occurred during setting subkey and value into parent key.");


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
Fixed errors reported by cppcheck 2.9.
Also changed the cppcheck version dependent bypass conditions.