### PR TITLE
Updated build_helper.sh for fixing a bug and installing ruby

### DIFF
--- a/.github/workflows/build_helper.sh
+++ b/.github/workflows/build_helper.sh
@@ -1100,11 +1100,11 @@ if [ "${CI_DO_PUBLISH}" -eq 1 ]; then
 			PRNERR "Failed to install SCL packages"
 			exit 1
 		fi
-		if ({ RUNCMD "${INSTALLER_BIN}" "${INSTALL_CMD}" "${INSTALL_CMD_ARG}" "${INSTALL_AUTO_ARG}" "${INSTALL_QUIET_ARG}" rh-ruby26 rh-ruby26-ruby-devel rh-ruby26-rubygem-rake || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+		if ({ RUNCMD "${INSTALLER_BIN}" "${INSTALL_CMD}" "${INSTALL_CMD_ARG}" "${INSTALL_AUTO_ARG}" "${INSTALL_QUIET_ARG}" rh-ruby27 rh-ruby27-ruby-devel rh-ruby27-rubygem-rake || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
 			PRNERR "Failed to install ruby packages"
 			exit 1
 		fi
-		. /opt/rh/rh-ruby26/enable
+		. /opt/rh/rh-ruby27/enable
 
 		if ({ RUNCMD "${GEM_BIN}" "${GEM_INSTALL_CMD}" package_cloud || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
 			PRNERR "Failed to install packagecloud.io upload tools"
@@ -1132,16 +1132,16 @@ if [ "${CI_DO_PUBLISH}" -eq 1 ]; then
 			PRNERR "Failed to reset ruby module"
 			exit 1
 		fi
-		if ({ RUNCMD "${INSTALLER_BIN}" module "${INSTALL_AUTO_ARG}" install ruby:2.6 || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
-			PRNERR "Failed to install ruby 2.6 module"
+		if ({ RUNCMD "${INSTALLER_BIN}" module "${INSTALL_AUTO_ARG}" install ruby:2.7 || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+			PRNERR "Failed to install ruby 2.7 module"
 			exit 1
 		fi
-		if ({ RUNCMD "${INSTALLER_BIN}" module "${INSTALL_AUTO_ARG}" enable ruby:2.6 || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
-			PRNERR "Failed to enable ruby 2.6 module"
+		if ({ RUNCMD "${INSTALLER_BIN}" module "${INSTALL_AUTO_ARG}" enable ruby:2.7 || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+			PRNERR "Failed to enable ruby 2.7 module"
 			exit 1
 		fi
-		if ({ RUNCMD "${INSTALLER_BIN}" module "${INSTALL_AUTO_ARG}" update ruby:2.6 || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
-			PRNERR "Failed to update ruby 2.6 module"
+		if ({ RUNCMD "${INSTALLER_BIN}" module "${INSTALL_AUTO_ARG}" update ruby:2.7 || echo > "${PIPEFAILURE_FILE}"; } | sed -e 's/^/    /g') && rm "${PIPEFAILURE_FILE}" >/dev/null 2>&1; then
+			PRNERR "Failed to update ruby 2.7 module"
 			exit 1
 		fi
 
@@ -1159,10 +1159,10 @@ if [ "${CI_DO_PUBLISH}" -eq 1 ]; then
 		#
 
 		#
-		# Set RVM(Ruby Version Manager) and install Ruby 2.6 and package_cloud
+		# Set RVM(Ruby Version Manager) and install Ruby 2.7 and package_cloud
 		#
 		# [NOTE]
-		# Install Ruby2.6 using RVM tools.
+		# Install Ruby2.7 using RVM tools.
 		# Installation and running RVM tools must be done in Bash.
 		# This set of installations will create a Bash script and run it.
 		#
@@ -1175,7 +1175,7 @@ if [ "${CI_DO_PUBLISH}" -eq 1 ]; then
 		#	command curl -sSL https://rvm.io/mpapis.asc | sudo gpg --import -
 		#	command curl -sSL https://rvm.io/pkuczynski.asc | sudo gpg --import -
 		#
-		# After that, install RVM installation, RVM environment settings, Ruby2.6 installation, and package_cloud tools.
+		# After that, install RVM installation, RVM environment settings, Ruby2.7 installation, and package_cloud tools.
 		#
 		# [NOTE]
 		# The RVM installation requires running from a bash shell.
@@ -1211,12 +1211,12 @@ if [ "${CI_DO_PUBLISH}" -eq 1 ]; then
 			echo '	echo "Failed to add rvm user to root group."'
 			echo '	exit 1'
 			echo 'fi'
-			echo 'if ! rvm install ruby-2.6 2>&1; then'
-			echo '	echo "Failed to install ruby 2.6."'
+			echo 'if ! rvm install ruby-2.7 2>&1; then'
+			echo '	echo "Failed to install ruby 2.7."'
 			echo '	exit 1'
 			echo 'fi'
-			echo 'if ! rvm --default use ruby-2.6 2>&1; then'
-			echo '	echo "Failed to set ruby 2.6 as default."'
+			echo 'if ! rvm --default use ruby-2.7 2>&1; then'
+			echo '	echo "Failed to set ruby 2.7 as default."'
 			echo '	exit 1'
 			echo 'fi'
 			echo ''
@@ -1392,7 +1392,7 @@ if [ "${RUN_SHELLCHECK}" -eq 1 ]; then
 		#
 		# Rocky
 		#
-		if ! LATEST_SHELLCHECK_DOWNLOAD_URL=$("${CURLCMD}" -s -S https://api.github.com/repos/koalaman/shellcheck/releases/latest | grep '"browser_download_url"' | grep 'linux.x86_64' | sed -e 's|"||g' -e 's|^.*browser_download_url:[[:space:]]*||g' -e 's|^[[:space:]]*||g' -e 's|[[:space:]]*$||g' | tr -d '\n'); then
+		if ! LATEST_SHELLCHECK_DOWNLOAD_URL=$("${CURLCMD}" -s -S https://api.github.com/repos/koalaman/shellcheck/releases/latest | tr '{' '\n' | tr '}' '\n' | tr '[' '\n' | tr ']' '\n' | tr ',' '\n' | grep '"browser_download_url"' | grep 'linux.x86_64' | sed -e 's|"||g' -e 's|^.*browser_download_url:[[:space:]]*||g' -e 's|^[[:space:]]*||g' -e 's|[[:space:]]*$||g' | tr -d '\n'); then
 			PRNERR "Failed to get shellcheck download url path"
 			exit 1
 		fi

--- a/buildutils/control.in
+++ b/buildutils/control.in
@@ -2,7 +2,7 @@ Source: @PACKAGE_NAME@
 Section: database
 Priority: optional
 Maintainer: @DEV_NAME@ <@DEV_EMAIL@>
-Build-Depends: @DEBHELPER_DEP@, k2hash-dev (>= 1.0.90), chmpx-dev (>= 1.0.103), libfullock-dev (>= 1.0.55), libyaml-dev, gnutls-dev
+Build-Depends: @DEBHELPER_DEP@, k2hash-dev (>= 1.0.92), chmpx-dev (>= 1.0.104), libfullock-dev (>= 1.0.57), libyaml-dev, gnutls-dev
 Standards-Version: 3.9.8
 Homepage: https://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@
 Vcs-Git: git://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@.git
@@ -11,7 +11,7 @@ Vcs-Browser: https://@GIT_DOMAIN@/@GIT_ORG@/@GIT_REPO@
 Package: @PACKAGE_NAME@-dev
 Section: devel
 Architecture: amd64
-Depends: ${misc:Depends}, @PACKAGE_NAME@ (= ${binary:Version}), k2hash-dev (>= 1.0.90), chmpx-dev (>= 1.0.103), libfullock-dev (>= 1.0.55), libyaml-dev, gnutls-dev
+Depends: ${misc:Depends}, @PACKAGE_NAME@ (= ${binary:Version}), k2hash-dev (>= 1.0.92), chmpx-dev (>= 1.0.104), libfullock-dev (>= 1.0.57), libyaml-dev, gnutls-dev
 Description: @SHORTDESC@ (development)
  Development package for building with @PACKAGE_NAME@ shared library.
   This package has header files and symbols for it.
@@ -19,6 +19,6 @@ Description: @SHORTDESC@ (development)
 Package: @PACKAGE_NAME@
 Section: database
 Architecture: amd64
-Depends: ${shlibs:Depends}, ${misc:Depends}, init-system-helpers (>= 1.14), k2hash (>= 1.0.90), chmpx (>= 1.0.103), libfullock (>= 1.0.55)
+Depends: ${shlibs:Depends}, ${misc:Depends}, init-system-helpers (>= 1.14), k2hash (>= 1.0.92), chmpx (>= 1.0.104), libfullock (>= 1.0.57)
 Description: @SHORTDESC@
 @DEBLONGDESC@

--- a/buildutils/k2hdkc.spec.in
+++ b/buildutils/k2hdkc.spec.in
@@ -53,11 +53,11 @@ License: @PKGLICENSE@
 @RPMPKG_GROUP@
 URL: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@
 Source0: https://@GIT_DOMAIN@/@GIT_ORG@/@PACKAGE_NAME@/archive/%{gittag}/%{name}-%{version}.tar.gz
-Requires: libfullock%{?_isa} >= 1.0.55, k2hash%{?_isa} >= 1.0.90, chmpx%{?_isa} >= 1.0.103
+Requires: libfullock%{?_isa} >= 1.0.57, k2hash%{?_isa} >= 1.0.92, chmpx%{?_isa} >= 1.0.104
 %if 0%{?rhel} == 6
-BuildRequires: git-core gcc-c++ make libtool libfullock-devel >= 1.0.55, k2hash-devel >= 1.0.90, chmpx-devel >= 1.0.103, libyaml-devel, nss-devel
+BuildRequires: git-core gcc-c++ make libtool libfullock-devel >= 1.0.57, k2hash-devel >= 1.0.92, chmpx-devel >= 1.0.104, libyaml-devel, nss-devel
 %else
-BuildRequires: systemd git-core gcc-c++ make libtool libfullock-devel >= 1.0.55, k2hash-devel >= 1.0.90, chmpx-devel >= 1.0.103, libyaml-devel, nss-devel
+BuildRequires: systemd git-core gcc-c++ make libtool libfullock-devel >= 1.0.57, k2hash-devel >= 1.0.92, chmpx-devel >= 1.0.104, libyaml-devel, nss-devel
 %endif
 
 %description
@@ -126,7 +126,7 @@ rm -rf %{buildroot}
 #
 %package devel
 Summary: @SHORTDESC@ (development)
-Requires: %{name}%{?_isa} = %{version}-%{release}, libfullock-devel%{?_isa} >= 1.0.55, k2hash-devel%{?_isa} >= 1.0.90, chmpx-devel%{?_isa} >= 1.0.103, libyaml-devel, nss-devel
+Requires: %{name}%{?_isa} = %{version}-%{release}, libfullock-devel%{?_isa} >= 1.0.57, k2hash-devel%{?_isa} >= 1.0.92, chmpx-devel%{?_isa} >= 1.0.104, libyaml-devel, nss-devel
 
 %description devel
 Development package for building with @PACKAGE_NAME@ shared library.

--- a/configure.ac
+++ b/configure.ac
@@ -154,9 +154,9 @@ AC_ARG_ENABLE(check-depend-libs,
 	esac]
 )
 AS_IF([test ${check_depend_libs} = 1], [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no)])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.55], [], [AC_MSG_ERROR(not found libfullock package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.90], [], [AC_MSG_ERROR(not found k2hash package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.103], [], [AC_MSG_ERROR(not found chmpx package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.57], [], [AC_MSG_ERROR(not found libfullock package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.92], [], [AC_MSG_ERROR(not found k2hash package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.104], [], [AC_MSG_ERROR(not found chmpx package)])])
 
 #
 # CFLAGS/CXXFLAGS


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
- There was a problem with the `shellcheck` installation process in `RockyLinux`'s `CI`, so we fixed `build_helper.sh`.
- The minimum Ruby version required for the `package_cloud` command has been changed to 2.7, and `build_helper.sh` has been modified accordingly.
- Also updated dependencies.