### PR TITLE
Updated dependent package versions and skip cppcheck on some OSes

### DIFF
--- a/.github/workflows/ostypevars.sh
+++ b/.github/workflows/ostypevars.sh
@@ -302,6 +302,15 @@ fi
 #	RUN_PUBLISH_PACKAGE		1
 #
 
+# [NOTE]
+# Running cppcheck on ALPINE and Fedora takes more than twice as long.
+# The same checks are performed on other OSes, so cppcheck will be
+# skipped on those OSes.
+#
+if echo "${CI_OSTYPE}" | grep -q -i -e 'alpine' -e 'fedora'; then
+	RUN_CPPCHECK=0
+fi
+
 #---------------------------------------------------------------
 # Variables for each process
 #---------------------------------------------------------------

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ CPPCHECK_BUILD_DIR		= /tmp/cppcheck
 CPPCHECK_BASE_OPT		= --quiet \
 						  --error-exitcode=1 \
 						  --inline-suppr \
-						  -j 8 \
+						  -j 16 \
 						  --std=c++03 \
 						  --xml
 CPPCHECK_ENABLE_OPT		= --enable=warning,style,information,missingInclude

--- a/configure.ac
+++ b/configure.ac
@@ -144,9 +144,9 @@ AS_IF([test "$PKG_CONFIG" = "no"], [AC_MSG_ERROR(You have to install pkg-config 
 #
 # Version list for Libraries
 #
-AC_SUBST([LIB_MINVER_CHMPX], "1.0.108")
-AC_SUBST([LIB_MINVER_LIBK2HASH], "1.0.98")
-AC_SUBST([LIB_MINVER_LIBFULLOCK], "1.0.62")
+AC_SUBST([LIB_MINVER_CHMPX], "1.0.109")
+AC_SUBST([LIB_MINVER_LIBK2HASH], "1.0.99")
+AC_SUBST([LIB_MINVER_LIBFULLOCK], "1.0.63")
 
 #
 # Checking Libraries
@@ -161,9 +161,9 @@ AC_ARG_ENABLE(check-depend-libs,
 	esac]
 )
 AS_IF([test ${check_depend_libs} = 1], [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(no)])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.62], [], [AC_MSG_ERROR(not found libfullock package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.98], [], [AC_MSG_ERROR(not found k2hash package)])])
-AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.108], [], [AC_MSG_ERROR(not found chmpx package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([fullock], [libfullock >= 1.0.63], [], [AC_MSG_ERROR(not found libfullock package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([k2hash], [libk2hash >= 1.0.99], [], [AC_MSG_ERROR(not found k2hash package)])])
+AS_IF([test ${check_depend_libs} = 1], [PKG_CHECK_MODULES([chmpx], [libchmpx >= 1.0.109], [], [AC_MSG_ERROR(not found chmpx package)])])
 
 #
 # CFLAGS/CXXFLAGS


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
The versions of dependent packages (`libfullock`, `k2hash`, `chmpx`) have been updated.